### PR TITLE
Initial repo reorg change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # Knative Infra
 
-_TODO(leads): please fill in this section_
+Welcome to the home of the [Infra(Productivity) working group](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#productivity)!
+This repo contains the configurations for the Knative infrastructure and is the starting point to the many other repos we maintain, see the list below. You can find us on the [Knative slack #productivity](https://slack.knative.dev/messages/productivity) channel.
+
+## Tools we use
+
+### Github Actions
+
+We use github actions for some automated tests, coordinating releases and syncronizing files between repos. For general information about github actions see github's [documentaion for actions](https://docs.github.com/en/actions).
+
+### TestGrid
+
+Knative provides a health dashboard to show test, code and release health for each repo. It covers key areas such as continuous integration, nightly release, conformance and etc. The testgrid dashboard is located at [testgrid.knative.dev](https://testgrid.knative.dev/).
+
+### E2E (end to end) Testing
+
+Our E2E testing uses kubetest2 to build/deploy/test Knative clusters (which are managed by Prow). For more information about kubenetes kubetest2 see the [kubetest2 documentation](https://github.com/kubernetes-sigs/kubetest2).
+
+### Prow
+
+We use Prow to verify commits before they are merged, trigger tests, handle the merge queue, trigger release builds, and much more. See the [prow/](prow/) directory in this repo for more information. The dashboard for prow is located at [prow.knative.dev](https://prow.knative.dev/).
+
+## Other repos we manage
+
+- [knative/.github](https://github.com/knative/.github) and [knative-sandbox/.github](https://github.com/knative-sandbox/.github) are used to sync certain files across repos such as our [CODE_OF_CONDUCT.md](https://github.com/knative/infra/blob/main/CODE_OF_CONDUCT.md) and other such files.
+
+- [knative/actions](https://github.com/knative/actions) contains reusable github workflows and actions.
+
+- [knative/hack](https://github.com/knative/hack) contains the shell scripts that are used across the repos.
+
+- [knative/release](https://github.com/knative/release) contains documentation and tools to aid in the Knative releases.
+
+- [knative-sandbox/actions-downstream-test](https://github.com/knative-sandbox/actions-downstream-test) contains a github action to test downstream repos upgradability from upstream repos.
+
+- [knative-sandbox/kperf](https://github.com/knative-sandbox/kperf) contains a performance test framework.
+
+- [knative-sandbox/knobots](https://github.com/knative-sandbox/knobots) which automates pull requests for routine maintenance tasks. Does this using github actions.

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,0 +1,50 @@
+# Prow
+
+Prow is the tool we use that triggers jobs based on events and mangages validation and other aspects of github. One can interact with it by using a chat-ops `/slash` type commands via github comments. For more infromation about Prow please see the [kubernetes Prow documentation](https://github.com/kubernetes/test-infra/tree/master/prow)
+
+## Summary of current directory
+
+Within each directory there will be a `README.md` that will go in to more details. Below is a summary:
+
+- `cluster-definitions` are the collection of deployment definitions for the different kubernetes clusters that are used by Prow.
+- `config` configurations for the different components of Prow.
+- `job-definitions` job definitions used by our slightly customized version of [prowgen](https://github.com/istio/test-infra/tree/master/tools/prowgen) config generation tool.
+- `jobs` are the actual job yaml that is either generated or hand-written that are used by Prow.
+- `Makefile` is an entry point to provide the initial deployment of the clusters explained in the cluster-definitions directory.
+
+## Overview of Prow componets we use
+
+### Core components
+
+We use the merge automation and all the core components outlined in the [kubernetes components documentation](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/README.md#core-components), with the exeption of using the older [plank](https://github.com/kubernetes/test-infra/tree/master/prow/plank) instead of the [prow-controller-manager](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/prow-controller-manager).
+
+### Other Components and Jobs
+
+- [`branchprotector`](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/branchprotector) which configures [github branch protection](https://help.github.com/articles/about-protected-branches/) according to a specified policy.
+- [`generic-autobumper`](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/generic-autobumper) which automates image version upgrades (e.g. for a Prow deployment) by opening a PR with images changed to their latest version according to a config file.
+- [`peribolos`](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/peribolos) which manages GitHub org, team and membership settings according to a config file(s) (found in the [community repo](https://github.com/knative/community/tree/main/peribolos)).
+- [`label_sync`](https://github.com/kubernetes/test-infra/tree/master/label_sync) which updates or migratse github labels on repos in a github org based on a YAML file. Our YAML file is located in the [community repo](https://github.com/knative/community/tree/main/label_sync).
+
+### Hook and it's plugins
+
+[Hook](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/hook) is the most important piece. It is a stateless server that listens for GitHub webhooks and dispatches them to the appropriate plugins. Hook's plugins are used to trigger jobs, implement 'slash' commands, post to Slack, and more. See the [prow/plugins](https://github.com/kubernetes/test-infra/blob/master/prow/plugins) directory for more information on plugins.
+The plugins we use can be found in the [hook-plugins.yaml](config/hook-plugins.yaml) file.
+
+## Simple Prow example
+
+A simplified example is given below, for the more detailed example see the [life of a Prow job documentation](https://github.com/kubernetes/test-infra/blob/master/prow/life_of_a_prow_job.md):
+
+1. User types in `/test all` as a comment into a GitHub PR.
+1. GitHub sends a webhook (HTTP request) to Prow, to the `prow.k8s.io/hook` endpoint.
+1. The request gets intercepted by the [ingress][ingress-yaml].
+1. The ingress routes the request to the **hook** [service][hook-service-yaml].
+1. The **hook** component process that request by finding the corresponding component/plugin.
+1. In this case, the component/plugin is **trigger**. (The pattern is that **hook** constructs objects to be consumed by various plugins.)
+1. **trigger** determines which presubmit jobs to run (because it sees the `/test` command in `/test all`).
+1. **trigger** creates a ProwJob object!
+1. **prow-controller-manager** creates a pod to start the ProwJob.
+1. When the ProwJob's pod finishes, **prow-controller-manager** updates the ProwJob.
+1. **crier** sees the updated ProwJob status and reports back to the GitHub PR (creating a new comment).
+1. **sinker** cleans up the old pod from above and deletes it from the Kubernetes API server.
+
+The [cluster-definitions/](cluster-definitions/) directory has more information about the different components/plugins and what they do. For more info about what a Prow job is, the [jobs/](jobs/) directory will have more information.

--- a/prow/cluster-definitions/README.md
+++ b/prow/cluster-definitions/README.md
@@ -1,0 +1,19 @@
+# Cluster deployment definitions
+
+This directory contains the definitions to deploy the following systems:
+
+- `Prow control plane cluster` is Prow, the Prow controller manager, and the different plugins/components for Prow. For more information of components please see the [kubernetes prow/cmd/ directory](https://github.com/kubernetes/test-infra/blob/master/prow/cmd).
+- `Build cluster` is the cluster which runs the Prow jobs that are dispatched from the Prow controller manager hosted on the control plane cluster.
+- `Boskos pool` is a pool of GCP projects that are used to run end to end tests that need a cluster to deploy a full knative distribution.
+
+## Summary of current directory
+
+- `build` has the definitions for the `Build cluster` outlined above.
+- `build/boskos-resources/boskos_resources.yaml` is the resources for the `Boskos pool` outlined above.
+- `core` has the definitions for the `Prow control plane cluster` outlined above.
+- `core/prowjob_customresourcedefinition.yaml` is the Prow job custom resource definition.
+- `monitoring` has the definitions for the monitoring the prow cluster. More information is contained in the `README.md` in this directory.
+
+## Notes on cluster yaml convention
+
+The folders that contain the different cluster definitions follow a `###-*.yaml` convention. The yaml files are meant to be applied from lowest to highest. An effort has been made to keep the yaml files as small and easy to read as possible. This will be different from the monolithic [starter-*.yaml](https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster/starter) file from the [Prow getting started guide](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md).

--- a/prow/configs/README.md
+++ b/prow/configs/README.md
@@ -1,0 +1,9 @@
+# Config
+
+This directory contains the configuration files for the different components of Prow as well as other tools that compliment the CI/CD system. More information about Prow components can be found in the [kubernetes prow/cmd/ directory](https://github.com/kubernetes/test-infra/blob/master/prow/cmd).
+
+## Summary of current directory
+
+- `testgrid/` contains the configuration for the testgrid dashboard that shows the pass/fail of our tests. Currently the deployment itself is hosted by Google. The deployment yaml that Google is using is [here](https://github.com/GoogleCloudPlatform/testgrid/tree/master/cluster/prod/knative). For a more detailed overview see the [original testgrid repo](https://github.com/GoogleCloudPlatform/testgrid).
+- `config.yaml` is configuration file for the Prow componentsin our Prow deployment. Documentation for those components are located in the [kubernetes prow/cmd/ directory](https://github.com/kubernetes/test-infra/blob/master/prow/cmd).
+- `plugins.yaml` contains the configuration for the different plugins for the Prow `hook` component. Hook is the component responcible for coordinating the Github events to the relevant Prow component. For more information on those plugins see the [kubernetes prow/plugins/ directory](https://github.com/kubernetes/test-infra/tree/master/prow/plugins)

--- a/prow/job-definitions/README.md
+++ b/prow/job-definitions/README.md
@@ -1,0 +1,13 @@
+# Prow job meta-definitions
+
+This directory contains the meta-definitions for Prow jobs. These meta-definitions are used by our [config-gen tool](../../config-gen/) that is based off of [istio's prowgen](https://github.com/istio/test-infra/tree/master/tools/prowgen). The meta-definitions use the [prowgen job syntax](https://github.com/istio/test-infra/tree/master/tools/prowgen#job-syntax). The generated jobs from these meta-definitions are put into the [../jobs/generated](../jobs/generated) directory. For more information about Prow jobs in general please see [kubernetes Prow Jobs documentation](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md).
+
+## Summary of current directory
+
+- `.base.yaml` is the base configuration that has common logic for all the jobs.
+- `knative` contains the Prow jobs layed out for the most part per repo for the knative org.
+- `knative-sandbox` contains the Prow jobs layed out for the most part per repo for the knative-sandbox org.
+
+## Notes on *-release-*.yaml files
+
+There are `*-release-*.yaml` files that are auto generated for some repos to track the release branches of those repos.

--- a/prow/jobs/README.md
+++ b/prow/jobs/README.md
@@ -1,0 +1,9 @@
+# Prow jobs
+
+This directory contains Prow jobs used by Prow. The generated prow jobs are made from the meta-definitions found in the [../job-definitions/](../job-definitions/) directory. It is encouraged to use that directory for any new jobs. There are handwritten jobs located here as well however. For more information about Prow jobs in general please see [kubernetes Prow Jobs documentation](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md).
+
+## Summary of current directory
+
+- `custom` directory contains handwritten Prow jobs. Please refrain from adding jobs here and add new jobs to the [../job-definitions/](../job-definitions/) directory.
+- `generated` contains the generated jobs from the meta-definitions defined in [../job-definitions/](../job-definitions/) directory.
+- `run_job.sh` is a useful convience script to run a job manually for testing purposes.


### PR DESCRIPTION
New READMEs and some migrated info from older ones. Below is proposed layout:

prow/
|- cluster-definitions/
|---- control-plane
|-------- 100-700-*.yaml (move from .)
|---- boskos*.yaml (remove parent folder, keep just the single yaml. This maybe should be moved this to the gcp/boskos folder)
|---- build/
|---- monitoring/
|---- prowjob-crd*.yml (remove parent folder)
|---- Makefile* (moved from ../)
|- job-definitions/ (renamed from jobs_config)
|- jobs/
|- config/
|---- prow-components.yaml (renamed from config.yaml)
|---- hook-plugins.yaml (renamed from plugins.yaml)
|---- labels.yaml (moved from config/label_sync)
|---- testgrid/
|-------- *-testgrid-*.yaml (moved from config/prow/k8s-testgrid)

gcp/
|- (move all infra/gcp files here)