### PR TITLE
Build release-jobs-syncer as part of the image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -198,10 +198,6 @@ RUN go install github.com/google/go-licenses@${GO_LICENSES_VERSION}
 RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 RUN go install github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}
 RUN go install github.com/sigstore/cosign/cmd/cosign@${COSIGN_VERSION}
-RUN go install knative.dev/toolbox/provenance-generator@${TOOLBOX_VERSION}
-RUN go install knative.dev/toolbox/pkg/clustermanager/perf-tests@${TOOLBOX_VERSION}
-RUN go install knative.dev/toolbox/kntest/cmd/kntest@${TOOLBOX_VERSION}
-RUN go get knative.dev/toolbox/release-jobs-syncer@${TOOLBOX_VERSION}
 
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?
@@ -209,6 +205,16 @@ RUN go install github.com/gogo/protobuf/protoc-gen-gogofaster@${PROTOC_GEN_GOGOF
 
 # Docker
 RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@${DOCKER_CREDENTIAL_GCR_VERSION}
+
+# Install tricky tools from knative/toolbox repo by cloning the repo.
+RUN git clone https://github.com/knative/toolbox.git /go/src/knative.dev/toolbox && \
+    cd /go/src/knative.dev/toolbox && \
+    git checkout ${TOOLBOX_VERSION}
+
+RUN go install /go/src/knative.dev/toolbox/release-jobs-syncer
+RUN go install /go/src/knative.dev/toolbox/provenance-generator
+RUN go install /go/src/knative.dev/toolbox/pkg/clustermanager/perf-tests
+RUN go install /go/src/knative.dev/toolbox/kntest/cmd/kntest
 
 # We do this instead of `go get` so the tools are locked to the Dockerfile's commit
 COPY . /go/src/knative.dev/infra

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -69,6 +69,7 @@ RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/googl
 RUN tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -C /
 RUN rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
 RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set core/disable_color true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \
     gcloud components install alpha beta gke-gcloud-auth-plugin && \
@@ -198,6 +199,9 @@ RUN go install github.com/google/go-licenses@${GO_LICENSES_VERSION}
 RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 RUN go install github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}
 RUN go install github.com/sigstore/cosign/cmd/cosign@${COSIGN_VERSION}
+RUN go install knative.dev/toolbox/provenance-generator@${TOOLBOX_VERSION}
+RUN go install knative.dev/toolbox/pkg/clustermanager/perf-tests@${TOOLBOX_VERSION}
+RUN go install knative.dev/toolbox/kntest/cmd/kntest@${TOOLBOX_VERSION}
 
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?
@@ -209,12 +213,8 @@ RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@${DOCKER_CRE
 # Install tricky tools from knative/toolbox repo by cloning the repo.
 RUN git clone https://github.com/knative/toolbox.git /go/src/knative.dev/toolbox && \
     cd /go/src/knative.dev/toolbox && \
-    git checkout ${TOOLBOX_VERSION}
-
-RUN go install /go/src/knative.dev/toolbox/release-jobs-syncer
-RUN go install /go/src/knative.dev/toolbox/provenance-generator
-RUN go install /go/src/knative.dev/toolbox/pkg/clustermanager/perf-tests
-RUN go install /go/src/knative.dev/toolbox/kntest/cmd/kntest
+    git checkout ${TOOLBOX_VERSION} && \
+    go install ./release-jobs-syncer
 
 # We do this instead of `go get` so the tools are locked to the Dockerfile's commit
 COPY . /go/src/knative.dev/infra

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -201,7 +201,7 @@ RUN go install github.com/sigstore/cosign/cmd/cosign@${COSIGN_VERSION}
 RUN go install knative.dev/toolbox/provenance-generator@${TOOLBOX_VERSION}
 RUN go install knative.dev/toolbox/pkg/clustermanager/perf-tests@${TOOLBOX_VERSION}
 RUN go install knative.dev/toolbox/kntest/cmd/kntest@${TOOLBOX_VERSION}
-RUN go install knative.dev/toolbox/release-jobs-syncer@${TOOLBOX_VERSION}
+RUN go get knative.dev/toolbox/release-jobs-syncer@${TOOLBOX_VERSION}
 
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -201,6 +201,7 @@ RUN go install github.com/sigstore/cosign/cmd/cosign@${COSIGN_VERSION}
 RUN go install knative.dev/toolbox/provenance-generator@${TOOLBOX_VERSION}
 RUN go install knative.dev/toolbox/pkg/clustermanager/perf-tests@${TOOLBOX_VERSION}
 RUN go install knative.dev/toolbox/kntest/cmd/kntest@${TOOLBOX_VERSION}
+RUN go install knative.dev/toolbox/release-jobs-syncer@${TOOLBOX_VERSION}
 
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?

--- a/images/prow-tests/cloudbuild.yaml
+++ b/images/prow-tests/cloudbuild.yaml
@@ -25,6 +25,9 @@ steps:
   - '-f'
   - 'images/prow-tests/Dockerfile'
   - '.'
+  env:
+  - 'NO_COLOR=1'
+  - 'BUILDKIT_PROGRESS=plain'
 - name: gcr.io/cloud-builders/docker
   args:
   - 'tag'


### PR DESCRIPTION
/cc @kvmware 

The `release-jobs-syncer` job is misconfigured right now and checks out the old repo. The tool needs to be compiled and called with the new repository.

https://github.com/knative/test-infra/pull/3840 needs to run in this repo which means the extra_refs have to be knative/infra and the job needs to look like this:

```yaml
- cron: "0 */2 * * *" # Every other hour
  name: ci-knative-prow-jobs-syncer
  agent: kubernetes
  decorate: true
  cluster: prow-build
  extra_refs:
  - org: knative
    repo: infra
    base_ref: main
    path_alias: knative.dev/infra
  annotations:
    testgrid-dashboards: utilities
    testgrid-tab-name: ci-knative-prow-jobs-syncer
  reporter_config:
    slack:
      channel: knative-productivity
      job_states_to_report:
        - failure
      report_template: '"The prow-jobs-syncer periodic job has failed, please check the logs: <{{.Status.URL}}|View logs>"'
  spec:
    containers:
    - image: gcr.io/knative-tests/test-infra/prow-tests:v20230524-3500eda5
      imagePullPolicy: Always
      command:
      - "runner.sh"
      args:
      - bash
      - -c
      - |
        release-jobs-syncer --github-account=/etc/prow-auto-bumper-github-token/token \
          --git-userid=knative-prow-updater-robot \
          --git-username='Knative Prow Updater Robot' \
          --git-email=knative-prow-updater-robot@google.com \
          --prow-job-config-root-path=prow/jobs_config \
          --regen-config-script=hack/generate-configs.sh \
          --label=skip-review
      volumeMounts:
      - name: github-credentials
        mountPath: /etc/prow-auto-bumper-github-token
        readOnly: true
      - name: ssh
        mountPath: /root/.ssh
    volumes:
    - name: github-credentials
      secret:
        secretName: github-credentials
        items:
        - key: auto_bumper_token
          path: token
    - name: ssh
      secret:
        secretName: github-credentials
        defaultMode: 0700
        items:
        - key: id_rsa
          path: id_rsa
        - key: id_rsa_pub
          path: id_rsa.pub
        - key: known_hosts
          path: known_hosts

```