### PR TITLE
Update the path for `flaky-test-recorder`

### DIFF
--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -171,7 +171,7 @@ periodics:
     - image: us-docker.pkg.dev/knative-tests/images/flaky-test-reporter:v20230605-4663f9da
       imagePullPolicy: Always
       command:
-      - "/flaky-test-reporter"
+      - "/tools/flaky-test-reporter"
       args:
       - "--github-account=/etc/flaky-test-reporter-github-token/token"
       - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
@@ -215,7 +215,7 @@ periodics:
     - image: us-docker.pkg.dev/knative-tests/images/flaky-test-reporter:v20230605-4663f9da
       imagePullPolicy: Always
       command:
-      - "/flaky-test-reporter"
+      - "/tools/flaky-test-reporter"
       args:
       - "--skip-report"
       - "--build-count=10"


### PR DESCRIPTION
/cc @kvmware 


The dockerfile's entrypoint was changed recently.

```Dockerfile
FROM golang:1.20.4

# Required input: -e TOOL_NAME=name, i.e. TOOL_NAME=flaky-test-reporter
ARG TOOL_NAME

RUN GOBIN=/tools go install "knative.dev/toolbox/${TOOL_NAME}@latest"

ENTRYPOINT ["/tools/${TOOL_NAME}"]
```