### PR TITLE
Use the prow-tests image for flaky jobs and bump release-jobs-syncer image

### DIFF
--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -168,13 +168,17 @@ periodics:
   spec:
     serviceAccountName: flaky-test-reporter
     containers:
-    - image: us-docker.pkg.dev/knative-tests/images/flaky-test-reporter:v20230605-4663f9da
+    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230607-36d2a7eb
       imagePullPolicy: Always
       command:
-      - "/tools/flaky-test-reporter"
+      - "runner.sh"
       args:
-      - "--github-account=/etc/flaky-test-reporter-github-token/token"
-      - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
+      - bash
+      - -c
+      - |
+        flaky-test-reporter \
+          --github-account=/etc/flaky-test-reporter-github-token/token \
+          --slack-account=/etc/flaky-test-reporter-slack-token/token
       volumeMounts:
       - name: github-credentials
         mountPath: /etc/flaky-test-reporter-github-token
@@ -212,13 +216,17 @@ periodics:
   spec:
     serviceAccountName: flaky-test-reporter
     containers:
-    - image: us-docker.pkg.dev/knative-tests/images/flaky-test-reporter:v20230605-4663f9da
+    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230607-36d2a7eb
       imagePullPolicy: Always
       command:
-      - "/tools/flaky-test-reporter"
+      - "runner.sh"
       args:
-      - "--skip-report"
-      - "--build-count=10"
+      - bash
+      - -c
+      - |
+        flaky-test-reporter \
+          --github-account=/etc/flaky-test-reporter-github-token/token \
+          --slack-account=/etc/flaky-test-reporter-slack-token/token
       volumeMounts:
       - name: github-credentials
         mountPath: /etc/flaky-test-reporter-github-token
@@ -261,7 +269,7 @@ periodics:
       report_template: '"The prow-jobs-syncer periodic job has failed, please check the logs: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
-    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230605-5de90de6
+    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230607-36d2a7eb
       imagePullPolicy: Always
       command:
       - "runner.sh"


### PR DESCRIPTION
/cc @kvmware 

The container bugs have been fixed. I manually submitted this prowjob, it is failing for other errors now.

https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-flakes-resultsrecorder/1666510717148205056

I also bumped the release-jobs-syncer job to pick up the fixes from https://github.com/knative/infra/pull/91