### PR TITLE
Use the fixed image for flaky-test-reporter

### DIFF
--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -168,7 +168,7 @@ periodics:
   spec:
     serviceAccountName: flaky-test-reporter
     containers:
-    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230607-36d2a7eb
+    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230608-1c1448d6
       imagePullPolicy: Always
       command:
       - "runner.sh"
@@ -216,7 +216,7 @@ periodics:
   spec:
     serviceAccountName: flaky-test-reporter
     containers:
-    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230607-36d2a7eb
+    - image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230608-1c1448d6
       imagePullPolicy: Always
       command:
       - "runner.sh"


### PR DESCRIPTION
Part of #100

/cc @kvmware 

Got a green run with the new image https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-flakes-resultsrecorder/1666862968031154176