### PR TITLE
Run flaky-test-reporter recorder with the correct flags

### DIFF
--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -225,8 +225,8 @@ periodics:
       - -c
       - |
         flaky-test-reporter \
-          --github-account=/etc/flaky-test-reporter-github-token/token \
-          --slack-account=/etc/flaky-test-reporter-slack-token/token
+          --skip-report \
+          --build-count=10
       volumeMounts:
       - name: github-credentials
         mountPath: /etc/flaky-test-reporter-github-token


### PR DESCRIPTION
/cc @kvmware 

Sometime during the repo shuffle, we set the incorrect flags for this job. The job in knative/test-infra has the flags that match this PR.

https://github.com/knative/test-infra/blob/main/prow/jobs/custom/test-infra.yaml#L219