### PR TITLE
Fix buildx flags

### DIFF
--- a/images/prow-tests/cloudbuild.yaml
+++ b/images/prow-tests/cloudbuild.yaml
@@ -22,6 +22,7 @@ steps:
   - 'COMMIT_HASH=${_COMMIT_HASH}'
   - '--no-cache'
   - '--pull'
+  - '--output=type=docker' # this won't work for when multi-arch image is introduced
   - '-t'
   - '${_IMG}:${_TAG}'
   - '-f'


### PR DESCRIPTION
/cc @kvmware 

The cloudbuild changes in #109 were missing an extra flag required to push images.