### PR TITLE
Make Github Actions optional for eventing-istio

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -236,6 +236,8 @@ tide:
             skip-unknown-contexts: true
           eventing-kafka-broker:
             skip-unknown-contexts: true
+          eventing-istio:
+            skip-unknown-contexts: true
           reconciler-test:
             skip-unknown-contexts: true
 #     orgs:


### PR DESCRIPTION
PRs stuck on shellchecks on git submodules.

/assign @pierDipi

(same as https://github.com/knative/test-infra/pull/3846, but test-infra repo is not used anymore)