### PR TITLE
chore: add presubmit job for func unit tests

### DIFF
--- a/prow/jobs/generated/knative/func-main.gen.yaml
+++ b/prow/jobs/generated/knative/func-main.gen.yaml
@@ -175,3 +175,28 @@ periodics:
         path: /sys/fs/cgroup
         type: Directory
       name: cgroup
+presubmits:
+  knative/func:
+  - always_run: true
+    branches:
+    - ^main$
+    cluster: prow-build
+    decorate: true
+    name: unit-tests_func_main
+    path_alias: knative.dev/func
+    rerun_command: /test unit-tests
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./test/presubmit-tests.sh
+        - --unit-tests
+        image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230616-086ddd644
+        name: ""
+        resources: {}
+        securityContext:
+          privileged: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        type: testing
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_func_main,?($|\s.*))

--- a/prow/jobs_config/knative/func.yaml
+++ b/prow/jobs_config/knative/func.yaml
@@ -4,6 +4,11 @@ branches: [main]
 image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230616-086ddd644
 
 jobs:
+  - name: unit-tests
+    types: [presubmit]
+    command: [runner.sh, ./test/presubmit-tests.sh, --unit-tests]
+    excluded_requirements: [gcp]
+
   - name: nightly
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release,


### PR DESCRIPTION
Adds a job for func unit tests. Doing this incrementally so that one issue at a time can be debugged.

Working to get knative/func more aligned with the existing test infra