### PR TITLE
add static external address for GKE ingress

### DIFF
--- a/infra/gcp/shared/address.tf
+++ b/infra/gcp/shared/address.tf
@@ -1,0 +1,8 @@
+# Based on https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs
+module "gke-ingress-address" {
+  source  = "terraform-google-modules/address/google"
+  version = "~> 3.1"
+
+  names  = [ "gke-ingress-ip"]
+  global = true
+}


### PR DESCRIPTION
First step for #173 

**What this PR does, why we need it**
Instead of exposing grafana directly, we can use GKE ingress solution. According to [their docs](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs) we first need a static external IP for this. This PR adds that.

/lint

