### PR TITLE
add new prow target for performance tests

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -1407,6 +1407,73 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    name: performance-tests_serving_main
+    optional: true
+    path_alias: knative.dev/serving
+    rerun_command: /test performance-tests
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./test/presubmit-tests.sh
+        - --run-test
+        - ./test/performance/performance-tests.sh
+        env:
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20230731-c57285e24
+        name: ""
+        resources:
+          limits:
+            memory: 16Gi
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /lib/modules
+          name: modules
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/influx-token-secret-volume
+          name: influx-token-secret-volume
+          readOnly: true
+        - mountPath: /etc/influx-url-secret-volume
+          name: influx-url-secret-volume
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        type: testing
+      serviceAccountName: test-runner
+      volumes:
+      - emptyDir: {}
+        name: docker-graph
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: influx-token-secret-volume
+        secret:
+          defaultMode: 384
+          secretName: influx-token-secret
+      - name: influx-url-secret-volume
+        secret:
+          defaultMode: 384
+          secretName: influx-url-secret
+    trigger: ((?m)^/test( | .* )performance-tests,?($|\s.*))|((?m)^/test( | .* )performance-tests_serving_main,?($|\s.*))
+  - always_run: false
+    branches:
+    - ^main$
+    cluster: prow-build
+    decorate: true
     name: performance-tests-kperf_serving_main
     optional: true
     path_alias: knative.dev/serving

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -28,6 +28,12 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh"]
 
+  - name: performance-tests
+    types: [presubmit]
+    requirements: [perf]
+    command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/performance/performance-tests.sh]
+    modifiers: [presubmit_optional, presubmit_skipped]
+
   - name: performance-tests-kperf
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/performance/performance-tests.sh]


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Belongs to https://github.com/knative/serving/pull/14289, detail: https://github.com/knative/serving/pull/14289#discussion_r1312698605

**What this PR does, why we need it**:
- Adds a new prow job to run performance tests without mako or kperf.

**Additional Notes**
- continuous target will be added later (when https://github.com/knative/serving/pull/14289 is merged)
- mako + kperf targets will be dropped later (when https://github.com/knative/serving/pull/14289 is merged and tests are stable)

