### PR TITLE
Bump go to 1.21

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -173,11 +173,11 @@ RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$
 # protoc-gen-gogofaster is installed below
 
 ############################################################
-FROM golang:1.19.11 AS external-go-previous
+FROM golang:1.20.7 AS external-go-previous
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 
-FROM golang:1.20.6 AS external-go-latest
+FROM golang:1.21.0 AS external-go-latest
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
         jq \
         procps \
         net-tools \
-        gnuplot
+        gnuplot \
+        bsdextrautils
 
 RUN pip3 install -U crcmod==1.7
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz

--- a/images/tool/Dockerfile
+++ b/images/tool/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.6
+FROM golang:1.21.0
 
 # Required input: -e TOOL_NAME=name, i.e. TOOL_NAME=flaky-test-reporter
 ARG TOOL_NAME


### PR DESCRIPTION
Also fixes the GVM issue we have been seeing.

https://github.com/moovweb/gvm/issues/438