### PR TITLE
increase timeout for performance tests

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -1407,6 +1407,8 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    decoration_config:
+      timeout: 3h0m0s
     name: performance-tests_serving_main
     optional: true
     path_alias: knative.dev/serving

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -29,6 +29,7 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh"]
 
   - name: performance-tests
+    timeout: 3h
     types: [presubmit]
     requirements: [perf]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/performance/performance-tests.sh]


### PR DESCRIPTION
**What this PR does, why we need it**:
- Increases the timeout for Serving performance tests
- This is necessary, as I added an additional test case, now the build takes longer than the default 2h

/assign @upodroid 