### PR TITLE
add `envsubst` to prow builder image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -66,7 +66,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
         procps \
         net-tools \
         gnuplot \
-        bsdextrautils
+        bsdextrautils \
+        gettext-base
 
 RUN pip3 install -U crcmod==1.7
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz


### PR DESCRIPTION
**What this PR does, why we need it**:
- Adding `envsubst` to prow builder image
- According to the conversation in: https://cloud-native.slack.com/archives/C04LMU0AX60/p1694433180978699?thread_ts=1694422110.571309&cid=C04LMU0AX60

/assign @upodroid 

I hope i got the right place to have `envsubst` in the prow CI runs.