### PR TITLE
pin rust to bullseye to compile rcodesign properly

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -45,29 +45,29 @@ ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
 
 # net-tools is used by serving tests
 RUN apt-get update -qqy && apt-get install -qqy \
-        curl \
-        gcc \
-        python3-dev \
-        python3-pip \
-        apt-transport-https \
-        lsb-release \
-        openssh-client \
-        ca-certificates \
-        git \
-        software-properties-common \
-        bison \
-        uuid-runtime \
-        shellcheck \
-        unzip \
-        zip \
-        wget \
-        gnupg \
-        jq \
-        procps \
-        net-tools \
-        gnuplot \
-        bsdextrautils \
-        gettext-base
+    curl \
+    gcc \
+    python3-dev \
+    python3-pip \
+    apt-transport-https \
+    lsb-release \
+    openssh-client \
+    ca-certificates \
+    git \
+    software-properties-common \
+    bison \
+    uuid-runtime \
+    shellcheck \
+    unzip \
+    zip \
+    wget \
+    gnupg \
+    jq \
+    procps \
+    net-tools \
+    gnuplot \
+    bsdextrautils \
+    gettext-base
 
 RUN pip3 install -U crcmod==1.7
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
@@ -246,7 +246,7 @@ RUN git clone https://github.com/kubernetes/kops /tmp/kops && cd /tmp/kops/tests
     go install .
 
 ############################################################
-FROM rust:1.72 AS external-rust-gets
+FROM rust:1.72-bullseye AS external-rust-gets
 
 ARG CODESIGN_VERSION=0.22.0
 # change this when a new version with https://github.com/indygreg/apple-platform-rs/pull/20 is cut
@@ -296,6 +296,7 @@ ENV USE_GKE_GCLOUD_AUTH_PLUGIN True
 
 # Extract versions
 RUN ko version > /ko_version
+RUN rcodesign --version 
 
 # Ensure docker config is in the final image
 RUN docker-credential-gcr configure-docker --registries=gcr.io,us-docker.pkg.dev


### PR DESCRIPTION
glibc compile errors :(

I need to look into how to do `CGO_ENABLED=0` for rust

https://storage.googleapis.com/knative-prow/logs/nightly_kn-plugin-operator_main_periodic/1706246691578974208/build-log.txt

/cc @kvmware @cardil 
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@ Notarizing macOS Binaries for the release @@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@ 2023-09-25 10:18:54.997020338+00:00
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by rcodesign)
  adding: kn-operator-darwin-amd64 (deflated 72%)
  adding: kn-operator-darwin-arm64 (deflated 73%)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by rcodesign)
rcodesign: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by rcodesign)
```