### PR TITLE
Make Loom and KEDA tests on demand tests

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -698,7 +698,7 @@ presubmits:
           type: Directory
         name: cgroup
     trigger: ((?m)^/test( | .* )reconciler-tests,?($|\s.*))|((?m)^/test( | .* )reconciler-tests_eventing-kafka-broker_main,?($|\s.*))
-  - always_run: true
+  - always_run: false
     branches:
     - ^main$
     cluster: prow-build
@@ -823,7 +823,7 @@ presubmits:
         name: cgroup
     trigger: ((?m)^/test( | .* )reconciler-tests-namespaced-broker,?($|\s.*))|((?m)^/test(
       | .* )reconciler-tests-namespaced-broker_eventing-kafka-broker_main,?($|\s.*))
-  - always_run: true
+  - always_run: false
     branches:
     - ^main$
     cluster: prow-build
@@ -887,7 +887,7 @@ presubmits:
         name: cgroup
     trigger: ((?m)^/test( | .* )reconciler-tests-namespaced-broker-loom,?($|\s.*))|((?m)^/test(
       | .* )reconciler-tests-namespaced-broker-loom_eventing-kafka-broker_main,?($|\s.*))
-  - always_run: true
+  - always_run: false
     branches:
     - ^main$
     cluster: prow-build

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
@@ -42,7 +42,7 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/reconciler-tests.sh"]
     requirements: [docker]
-    modifiers: [presubmit_optional]
+    modifiers: [presubmit_optional, presubmit_skipped]
     env:
       - name: BROKER_CLASS
         value: Kafka
@@ -61,17 +61,18 @@ jobs:
     types: [ presubmit ]
     command: [ runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/reconciler-tests.sh" ]
     requirements: [ docker ]
-    modifiers: [presubmit_optional]
+    modifiers: [presubmit_optional, presubmit_skipped]
     env:
       - name: BROKER_CLASS
         value: KafkaNamespaced
       - name: USE_LOOM
         value: "true"
+
   - name: reconciler-tests-keda
     types: [ presubmit ]
     command: [ runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/keda-reconciler-tests.sh"]
     requirements: [ docker ]
-    modifiers: [ presubmit_optional ]
+    modifiers: [presubmit_optional, presubmit_skipped]
     env:
       - name: BROKER_CLASS
         value: Kafka


### PR DESCRIPTION
These 2 jobs don't need to run every time, devs can trigger them when it's actually needed.