### PR TITLE
Bump Go verions to latest patch release

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -175,11 +175,11 @@ RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$
 # protoc-gen-gogofaster is installed below
 
 ############################################################
-FROM golang:1.20.8 AS external-go-previous
+FROM golang:1.20.10 AS external-go-previous
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 
-FROM golang:1.21.1 AS external-go-latest
+FROM golang:1.21.3 AS external-go-latest
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 

--- a/images/tool/Dockerfile
+++ b/images/tool/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.1
+FROM golang:1.21.3
 
 # Required input: -e TOOL_NAME=name, i.e. TOOL_NAME=flaky-test-reporter
 ARG TOOL_NAME


### PR DESCRIPTION
To have infra ready in response to https://nvd.nist.gov/vuln/detail/CVE-2023-44487.

/cc @knative/productivity-leads 
/cc @knative/security-wg-leads 