### PR TITLE
re-enable keda tests for ekb

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -1109,13 +1109,12 @@ presubmits:
         name: cgroup
     trigger: ((?m)^/test( | .* )reconciler-tests-namespaced-broker-loom,?($|\s.*))|((?m)^/test(
       | .* )reconciler-tests-namespaced-broker-loom_eventing-kafka-broker_main,?($|\s.*))
-  - always_run: false
+  - always_run: true
     branches:
     - ^main$
     cluster: prow-build
     decorate: true
     name: reconciler-tests-keda_eventing-kafka-broker_main
-    optional: true
     path_alias: knative.dev/eventing-kafka-broker
     rerun_command: /test reconciler-tests-keda
     spec:

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
@@ -72,7 +72,6 @@ jobs:
     types: [ presubmit ]
     command: [ runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/keda-reconciler-tests.sh"]
     requirements: [ docker ]
-    modifiers: [presubmit_optional, presubmit_skipped]
     env:
       - name: BROKER_CLASS
         value: Kafka


### PR DESCRIPTION
This PR re-enables the keda tests in eventing kafka broker now that they are passing thanks to https://github.com/knative-extensions/eventing-kafka-broker/pull/3479