### PR TITLE
Bump argocd, Grafana and ESO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bazel-*
+*.tgz
 *~
 .idea/
 .vscode/

--- a/prow/cluster/gitops/apps/eso-prow-build.yaml
+++ b/prow/cluster/gitops/apps/eso-prow-build.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: v0.5.8
+    targetRevision: v0.9.9
     helm:
       releaseName: external-secrets
       parameters:

--- a/prow/cluster/gitops/apps/eso-prow.yaml
+++ b/prow/cluster/gitops/apps/eso-prow.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: v0.5.8
+    targetRevision: v0.9.9
     helm:
       releaseName: external-secrets
       parameters:

--- a/prow/cluster/gitops/apps/eso-trusted.yaml
+++ b/prow/cluster/gitops/apps/eso-trusted.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: v0.5.8
+    targetRevision: v0.9.9
     helm:
       releaseName: external-secrets
       parameters:

--- a/prow/cluster/gitops/bootstrap/kustomization.yaml
+++ b/prow/cluster/gitops/bootstrap/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/argoproj/argo-cd/manifests/ha/base?ref=v2.7.2
+- github.com/argoproj/argo-cd/manifests/ha/base?ref=v2.9.2
 - extras.yaml
 
-patchesStrategicMerge:
-- argocd-server-service.yaml
-- argocd-cm.yaml
-- argocd-cm-rbac.yaml
+patches:
+- path: argocd-server-service.yaml
+- path: argocd-cm.yaml
+- path: argocd-cm-rbac.yaml

--- a/prow/cluster/monitoring/chart/Chart.lock
+++ b/prow/cluster/monitoring/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.33.0
-digest: sha256:bb3a030b1678984e7d58d1828dfdf9cd67706d4c91fb7dd2a421ab5736bc61ca
-generated: "2022-08-25T17:47:25.319482+01:00"
+  version: 7.0.8
+digest: sha256:152b202772bba57b3d445ba7f76e56bf836e88e1782c7fda48779cb20cd53ce5
+generated: "2023-11-25T10:48:09.906972Z"

--- a/prow/cluster/monitoring/chart/Chart.yaml
+++ b/prow/cluster/monitoring/chart/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: monitoring
 type: application
-version: 6.33.0
-appVersion: 9.0.5
+version: 7.0.8
+appVersion: 10.1.5
 dependencies:
 - name: grafana
-  version: 6.33.0
+  version: 7.0.8
   repository: https://grafana.github.io/helm-charts

--- a/prow/cluster/monitoring/chart/values.yaml
+++ b/prow/cluster/monitoring/chart/values.yaml
@@ -1,6 +1,4 @@
 grafana:
-  image:
-    tag: 9.1.1
   resources:
    limits:
      cpu: 4000m
@@ -24,6 +22,8 @@ grafana:
   persistence:
     enabled: true
     size: 50Gi
+  rbac:
+    pspEnabled: false
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
I upgraded all the clusters to 1.25 and bumped ArgoCD to 2.9

I'm going to keep upgrading the Kubernetes clusters to 1.27 by the end of this week.