### PR TITLE
Bump Golang to latest patch release

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -175,11 +175,11 @@ RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$
 # protoc-gen-gogofaster is installed below
 
 ############################################################
-FROM golang:1.20.10 AS external-go-previous
+FROM golang:1.20.11 AS external-go-previous
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 
-FROM golang:1.21.3 AS external-go-latest
+FROM golang:1.21.4 AS external-go-latest
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 

--- a/images/tool/Dockerfile
+++ b/images/tool/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.3
+FROM golang:1.21.4
 
 # Required input: -e TOOL_NAME=name, i.e. TOOL_NAME=flaky-test-reporter
 ARG TOOL_NAME


### PR DESCRIPTION

The newer patch version of Golang should fix the issue with license check. 

Reported here as well: https://cloud-native.slack.com/archives/C04LKEZUXEE/p1700817496481049

**1.21.3**
```
➜  client git:(auto-updates/update-deps-main) eval "$(gvm 1.21.3)"
➜  client git:(auto-updates/update-deps-main) go-licenses check ./...
E1129 09:59:30.412368   20088 library.go:117] Package errors does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.
E1129 09:59:30.412515   20088 library.go:117] Package fmt does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.
E1129 09:59:30.414523   20088 library.go:117] Package bytes does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.
E1129 09:59:30.414531   20088 library.go:117] Package os does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.
E1129 09:59:30.414535   20088 library.go:117] Package os/exec does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.
E1129 09:59:30.414538   20088 library.go:117] Package path/filepath does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.
W1129 09:59:30.414544   20088 library.go:101] "runtime" contains non-Go code that can't be inspected for further dependencies:
```

**1.21.4**
```
➜  client git:(auto-updates/update-deps-main) eval "$(gvm 1.21.4)"
➜  client git:(auto-updates/update-deps-main) echo $GOROOT
/Users/dsimansk/.gvm/versions/go1.21.4.darwin.arm64
➜  client git:(auto-updates/update-deps-main) go-licenses check ./...
W1129 09:58:44.215024   19906 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/dsimansk/Git/knative/client/vendor/golang.org/x/sys/unix/asm_bsd_arm64.s
/Users/dsimansk/Git/knative/client/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
W1129 09:58:45.275226   19906 library.go:101] "github.com/modern-go/reflect2" contains non-Go code that can't be inspected for further dependencies:
/Users/dsimansk/Git/knative/client/vendor/github.com/modern-go/reflect2/relfect2_arm64.s
/Users/dsimansk/Git/knative/client/vendor/github.com/modern-go/reflect2/relfect2_mips64x.s
/Users/dsimansk/Git/knative/client/vendor/github.com/modern-go/reflect2/relfect2_mipsx.s
/Users/dsimansk/Git/knative/client/vendor/github.com/modern-go/reflect2/relfect2_ppc64x.s
W1129 09:58:52.017968   19906 library.go:101] "github.com/cespare/xxhash/v2" contains non-Go code that can't be inspected for further dependencies:
/Users/dsimansk/Git/knative/client/vendor/github.com/cespare/xxhash/v2/xxhash_arm64.s
W1129 09:58:54.418513   19906 library.go:101] "go.starlark.net/starlark" contains non-Go code that can't be inspected for further dependencies:
/Users/dsimansk/Git/knative/client/vendor/go.starlark.net/starlark/empty.s
```

/cc @knative/productivity-reviewers 
/cc @matejvasek @cardil 
