### PR TITLE
Turn on signing and attestation for serving

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -774,6 +774,10 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
+      - name: SIGN_IMAGES
+        value: "true"
+      - name: ATTEST_IMAGES
+        value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20231207-30ee442a2
       name: ""
       resources:
@@ -846,6 +850,10 @@ periodics:
         value: "true"
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: SIGN_IMAGES
+        value: "true"
+      - name: ATTEST_IMAGES
+        value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20231207-30ee442a2
       name: ""
       resources:

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -855,6 +855,10 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
+      - name: SIGN_IMAGES
+        value: "true"
+      - name: ATTEST_IMAGES
+        value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20231129-81431e1fe
       name: ""
       resources:
@@ -927,6 +931,10 @@ periodics:
         value: "true"
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: SIGN_IMAGES
+        value: "true"
+      - name: ATTEST_IMAGES
+        value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20231129-81431e1fe
       name: ""
       resources:

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -283,6 +283,10 @@ requirement_presets:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
+      - name: SIGN_IMAGES
+        value: "true"
+      - name: ATTEST_IMAGES
+        value: "true"
     volumeMounts:
       - name: nightly-account
         mountPath: /etc/nightly-account
@@ -301,6 +305,10 @@ requirement_presets:
     env:
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: SIGN_IMAGES
+        value: "true"
+      - name: ATTEST_IMAGES
+        value: "true"
     volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token


### PR DESCRIPTION
<!--
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
-->
**Which issue(s) this PR fixes**:<br>
Fixes #287

I think there's something in the environment overrides that caused `.base.yaml` to not apply for Serving, but this seems to have fixed it.  I assumed we'd want any further patch releases on the existing lines to get signatures + attestations, so I updates the existing releases as well.


<!--
  If there is any golang code in this PR please uncomment the
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
/lint
-->
