### PR TITLE
Bump Golang to 1.21.5

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -175,11 +175,11 @@ RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$
 # protoc-gen-gogofaster is installed below
 
 ############################################################
-FROM golang:1.20.11 AS external-go-previous
+FROM golang:1.20.12 AS external-go-previous
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 
-FROM golang:1.21.4 AS external-go-latest
+FROM golang:1.21.5 AS external-go-latest
 # Capture the version that dependabot bumps so that we can install it into the base image
 RUN go version | cut -d' ' -f3 > /golang.version
 

--- a/images/tool/Dockerfile
+++ b/images/tool/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.4
+FROM golang:1.21.5
 
 # Required input: -e TOOL_NAME=name, i.e. TOOL_NAME=flaky-test-reporter
 ARG TOOL_NAME


### PR DESCRIPTION
To address https://pkg.go.dev/vuln/GO-2023-2382.

/cc @dprotaso @evankanderson @upodroid 