### PR TITLE
Update the Cron job timings for ppc64le to add 1.13 release jobs

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -311,7 +311,7 @@ periodics:
     testgrid-dashboards: eventing-kafka-broker
     testgrid-tab-name: ppc64le-e2e-tests-ssl
   cluster: prow-build
-  cron: 10 12 * * *
+  cron: 20 9 * * *
   decorate: true
   extra_refs:
   - base_ref: main
@@ -467,7 +467,7 @@ periodics:
     testgrid-dashboards: eventing-kafka-broker
     testgrid-tab-name: ppc64le-e2e-tests-sasl-ssl
   cluster: prow-build
-  cron: 20 6 * * *
+  cron: 50 4 * * *
   decorate: true
   extra_refs:
   - base_ref: main
@@ -623,7 +623,7 @@ periodics:
     testgrid-dashboards: eventing-kafka-broker
     testgrid-tab-name: ppc64le-e2e-tests-sasl-plain
   cluster: prow-build
-  cron: 0 1 * * *
+  cron: 0 0 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.11.gen.yaml
@@ -238,7 +238,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.11
     testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-ssl
   cluster: prow-build
-  cron: 10 13 * * *
+  cron: 20 12 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11
@@ -394,7 +394,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.11
     testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-sasl-ssl
   cluster: prow-build
-  cron: 0 8 * * *
+  cron: 50 7 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11
@@ -550,7 +550,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.11
     testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-sasl-plain
   cluster: prow-build
-  cron: 0 2 * * *
+  cron: 50 3 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.12.gen.yaml
@@ -402,7 +402,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.12
     testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-ssl
   cluster: prow-build
-  cron: 40 15 * * *
+  cron: 20 11 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12
@@ -476,7 +476,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.12
     testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-sasl-ssl
   cluster: prow-build
-  cron: 30 10 * * *
+  cron: 50 6 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12
@@ -550,7 +550,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.12
     testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-sasl-plain
   cluster: prow-build
-  cron: 20 5 * * *
+  cron: 0 2 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
@@ -111,7 +111,7 @@ periodics:
     testgrid-dashboards: kn-plugin-event
     testgrid-tab-name: ppc64le-e2e-tests
   cluster: prow-build
-  cron: 30 4 * * *
+  cron: 0 3 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.11.gen.yaml
@@ -186,7 +186,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.11
     testgrid-tab-name: kn-plugin-event-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 10 21 * * *
+  cron: 40 14 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.12.gen.yaml
@@ -186,7 +186,7 @@ periodics:
     testgrid-dashboards: knative-extensions-release-1.12
     testgrid-tab-name: kn-plugin-event-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 35 17 * * *
+  cron: 00 14 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -167,7 +167,7 @@ periodics:
     testgrid-dashboards: client
     testgrid-tab-name: ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 3 * * *
+  cron: 45 1 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/client-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.11.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.11
     testgrid-tab-name: client-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 50 16 * * *
+  cron: 45 17 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11

--- a/prow/jobs/generated/knative/client-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.12.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.12
     testgrid-tab-name: client-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 20 20 * * *
+  cron: 45 12 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12

--- a/prow/jobs/generated/knative/client-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.13.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.13
     testgrid-tab-name: client-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 3 * * *
+  cron: 30 7 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.13
@@ -147,7 +147,7 @@ periodics:
       - runner.sh
       env:
       - name: CI_JOB
-        value: client-main
+        value: client-release-1.13
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
       - name: E2E_CLUSTER_REGION

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -218,7 +218,7 @@ periodics:
     testgrid-dashboards: eventing
     testgrid-tab-name: ppc64le-e2e-tests
   cluster: prow-build
-  cron: 15 4 * * *
+  cron: 45 2 * * *
   decorate: true
   extra_refs:
   - base_ref: main
@@ -290,7 +290,7 @@ periodics:
     testgrid-dashboards: eventing
     testgrid-tab-name: ppc64le-e2e-reconciler-tests
   cluster: prow-build
-  cron: 40 1 * * *
+  cron: 30 0 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/eventing-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.11.gen.yaml
@@ -218,7 +218,7 @@ periodics:
     testgrid-dashboards: knative-release-1.11
     testgrid-tab-name: eventing-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 17 * * *
+  cron: 15 15 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11
@@ -290,7 +290,7 @@ periodics:
     testgrid-dashboards: knative-release-1.11
     testgrid-tab-name: eventing-ppc64le-e2e-reconciler-tests
   cluster: prow-build
-  cron: 30 15 * * *
+  cron: 10 14 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11

--- a/prow/jobs/generated/knative/eventing-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.12.gen.yaml
@@ -218,7 +218,7 @@ periodics:
     testgrid-dashboards: knative-release-1.12
     testgrid-tab-name: eventing-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 21 * * *
+  cron: 15 13 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12
@@ -290,7 +290,7 @@ periodics:
     testgrid-dashboards: knative-release-1.12
     testgrid-tab-name: eventing-ppc64le-e2e-reconciler-tests
   cluster: prow-build
-  cron: 40 19 * * *
+  cron: 30 11 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12

--- a/prow/jobs/generated/knative/eventing-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.13.gen.yaml
@@ -218,7 +218,7 @@ periodics:
     testgrid-dashboards: knative-release-1.13
     testgrid-tab-name: eventing-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 15 4 * * *
+  cron: 30 8 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.13
@@ -239,7 +239,7 @@ periodics:
       - runner.sh
       env:
       - name: CI_JOB
-        value: eventing-main
+        value: eventing-release-1.13
       - name: SCALE_CHAOSDUCK_TO_ZERO
         value: "1"
       - name: SYSTEM_NAMESPACE
@@ -290,7 +290,7 @@ periodics:
     testgrid-dashboards: knative-release-1.13
     testgrid-tab-name: eventing-ppc64le-e2e-reconciler-tests
   cluster: prow-build
-  cron: 40 1 * * *
+  cron: 10 6 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.13
@@ -311,7 +311,7 @@ periodics:
       - runner.sh
       env:
       - name: CI_JOB
-        value: eventing_rekt-main
+        value: eventing_rekt-release-1.13
       - name: SCALE_CHAOSDUCK_TO_ZERO
         value: "1"
       - name: SYSTEM_NAMESPACE

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: operator
     testgrid-tab-name: ppc64le-e2e-tests
   cluster: prow-build
-  cron: 10 5 * * *
+  cron: 40 3 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/operator-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.11.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.11
     testgrid-tab-name: operator-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 20 12 * * *
+  cron: 30 15 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11

--- a/prow/jobs/generated/knative/operator-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.12.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.12
     testgrid-tab-name: operator-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 22 * * *
+  cron: 40 13 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12

--- a/prow/jobs/generated/knative/operator-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.13.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.13
     testgrid-tab-name: operator-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 10 5 * * *
+  cron: 30 9 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.13
@@ -147,7 +147,7 @@ periodics:
       - runner.sh
       env:
       - name: CI_JOB
-        value: operator-main
+        value: operator-release-1.13
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
       - name: E2E_CLUSTER_REGION

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -661,7 +661,7 @@ periodics:
     testgrid-dashboards: serving
     testgrid-tab-name: ppc64le-kourier-tests
   cluster: prow-build
-  cron: 40 5 * * *
+  cron: 30 4 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/serving-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.11.gen.yaml
@@ -244,7 +244,7 @@ periodics:
     testgrid-dashboards: knative-release-1.11
     testgrid-tab-name: serving-ppc64le-kourier-tests
   cluster: prow-build
-  cron: 10 18 * * *
+  cron: 10 16 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.11

--- a/prow/jobs/generated/knative/serving-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.12.gen.yaml
@@ -244,7 +244,7 @@ periodics:
     testgrid-dashboards: knative-release-1.12
     testgrid-tab-name: serving-ppc64le-kourier-tests
   cluster: prow-build
-  cron: 20 22 * * *
+  cron: 0 16 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.12

--- a/prow/jobs/generated/knative/serving-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.13.gen.yaml
@@ -244,7 +244,7 @@ periodics:
     testgrid-dashboards: knative-release-1.13
     testgrid-tab-name: serving-ppc64le-kourier-tests
   cluster: prow-build
-  cron: 40 5 * * *
+  cron: 0 10 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.13
@@ -266,7 +266,7 @@ periodics:
       - runner.sh
       env:
       - name: CI_JOB
-        value: kourier-main
+        value: kourier-release-1.13
       - name: SYSTEM_NAMESPACE
         value: knative-serving
       - name: TEST_OPTIONS

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker-release-1.11.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker-release-1.11.yaml
@@ -232,7 +232,7 @@ jobs:
     - name: BROKER_CLASS
       value: Kafka
 - name: ppc64le-e2e-tests-ssl
-  cron: 10 13 * * *
+  cron: 20 12 * * *
   types: [periodic]
   requirements: [ppc64le]
   command: [runner.sh]
@@ -285,7 +285,7 @@ jobs:
     - name: BROKER_CLASS
       value: Kafka
 - name: ppc64le-e2e-tests-sasl-ssl
-  cron: 0 8 * * *
+  cron: 50 7 * * *
   types: [periodic]
   requirements: [ppc64le]
   command: [runner.sh]
@@ -338,7 +338,7 @@ jobs:
     - name: BROKER_CLASS
       value: Kafka
 - name: ppc64le-e2e-tests-sasl-plain
-  cron: 0 2 * * *
+  cron: 50 3 * * *
   types: [periodic]
   requirements: [ppc64le]
   command: [runner.sh]

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker-release-1.12.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker-release-1.12.yaml
@@ -340,7 +340,7 @@ jobs:
     - name: BROKER_CLASS
       value: Kafka
 - name: ppc64le-e2e-tests-ssl
-  cron: 40 15 * * *
+  cron: 20 11 * * *
   types: [periodic]
   requirements: [ppc64le]
   command: [runner.sh]
@@ -365,7 +365,7 @@ jobs:
     - name: BROKER_CLASS
       value: Kafka
 - name: ppc64le-e2e-tests-sasl-ssl
-  cron: 30 10 * * *
+  cron: 50 6 * * *
   types: [periodic]
   requirements: [ppc64le]
   command: [runner.sh]
@@ -390,7 +390,7 @@ jobs:
     - name: BROKER_CLASS
       value: Kafka
 - name: ppc64le-e2e-tests-sasl-plain
-  cron: 20 5 * * *
+  cron: 0 2 * * *
   types: [periodic]
   requirements: [ppc64le]
   command: [runner.sh]

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
@@ -201,7 +201,7 @@ jobs:
         value: Kafka
 
   - name: ppc64le-e2e-tests-ssl
-    cron: 10 12 * * *
+    cron: 20 9 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]
@@ -256,7 +256,7 @@ jobs:
         value: Kafka
 
   - name: ppc64le-e2e-tests-sasl-ssl
-    cron: 20 6 * * *
+    cron: 50 4 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]
@@ -311,7 +311,7 @@ jobs:
         value: Kafka
 
   - name: ppc64le-e2e-tests-sasl-plain
-    cron: 0 1 * * *
+    cron: 0 0 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]

--- a/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.11.yaml
+++ b/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.11.yaml
@@ -102,7 +102,7 @@ jobs:
     value: /tmp/ssl.crt
   command:
   - runner.sh
-  cron: 10 21 * * *
+  cron: 40 14 * * *
   name: ppc64le-e2e-tests
   requirements:
   - ppc64le

--- a/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.12.yaml
+++ b/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.12.yaml
@@ -102,7 +102,7 @@ jobs:
     value: /tmp/ssl.crt
   command:
   - runner.sh
-  cron: 35 17 * * *
+  cron: 00 14 * * *
   name: ppc64le-e2e-tests
   requirements:
   - ppc64le

--- a/prow/jobs_config/knative-extensions/kn-plugin-event.yaml
+++ b/prow/jobs_config/knative-extensions/kn-plugin-event.yaml
@@ -41,7 +41,7 @@ jobs:
     excluded_requirements:
     - gcp
   - name: ppc64le-e2e-tests
-    cron: 30 4 * * *
+    cron: 0 3 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]

--- a/prow/jobs_config/knative/client-release-1.11.yaml
+++ b/prow/jobs_config/knative/client-release-1.11.yaml
@@ -79,7 +79,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 50 16 * * *
+  cron: 45 17 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/client-release-1.12.yaml
+++ b/prow/jobs_config/knative/client-release-1.12.yaml
@@ -79,7 +79,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 20 * * *
+  cron: 45 12 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/client-release-1.13.yaml
+++ b/prow/jobs_config/knative/client-release-1.13.yaml
@@ -79,12 +79,12 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 0 3 * * *
+  cron: 30 7 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev
   - name: CI_JOB
-    value: client-main
+    value: client-release-1.13
   name: ppc64le-e2e-tests
   requirements:
   - ppc64le

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -53,7 +53,7 @@ jobs:
         value: contour.ingress.networking.knative.dev
 
   - name: ppc64le-e2e-tests
-    cron: 0 3 * * *
+    cron: 45 1 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]

--- a/prow/jobs_config/knative/eventing-release-1.11.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.11.yaml
@@ -118,7 +118,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 0 17 * * *
+  cron: 15 15 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
@@ -140,7 +140,7 @@ jobs:
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 30 15 * * *
+  cron: 10 14 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/eventing-release-1.12.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.12.yaml
@@ -118,7 +118,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 0 21 * * *
+  cron: 15 13 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
@@ -140,7 +140,7 @@ jobs:
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 40 19 * * *
+  cron: 30 11 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/eventing-release-1.13.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.13.yaml
@@ -118,14 +118,14 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 15 4 * * *
+  cron: 30 8 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
   - name: SCALE_CHAOSDUCK_TO_ZERO
     value: "1"
   - name: CI_JOB
-    value: eventing-main
+    value: eventing-release-1.13
   name: ppc64le-e2e-tests
   requirements:
   - ppc64le
@@ -140,14 +140,14 @@ jobs:
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 40 1 * * *
+  cron: 10 6 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
   - name: SCALE_CHAOSDUCK_TO_ZERO
     value: "1"
   - name: CI_JOB
-    value: eventing_rekt-main
+    value: eventing_rekt-release-1.13
   name: ppc64le-e2e-reconciler-tests
   requirements:
   - ppc64le

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -79,7 +79,7 @@ jobs:
         value: "1"
 
   - name: ppc64le-e2e-tests
-    cron: 15 4 * * *
+    cron: 45 2 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]
@@ -99,7 +99,7 @@ jobs:
         value: "eventing-main"
 
   - name: ppc64le-e2e-reconciler-tests
-    cron: 40 1 * * *
+    cron: 30 0 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]

--- a/prow/jobs_config/knative/operator-release-1.11.yaml
+++ b/prow/jobs_config/knative/operator-release-1.11.yaml
@@ -96,7 +96,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 12 * * *
+  cron: 30 15 * * *
   env:
   - name: CI_JOB
     value: operator-release-1.11

--- a/prow/jobs_config/knative/operator-release-1.12.yaml
+++ b/prow/jobs_config/knative/operator-release-1.12.yaml
@@ -96,7 +96,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 0 22 * * *
+  cron: 40 13 * * *
   env:
   - name: CI_JOB
     value: operator-release-1.12

--- a/prow/jobs_config/knative/operator-release-1.13.yaml
+++ b/prow/jobs_config/knative/operator-release-1.13.yaml
@@ -96,10 +96,10 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 10 5 * * *
+  cron: 30 9 * * *
   env:
   - name: CI_JOB
-    value: operator-main
+    value: operator-release-1.13
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev
   name: ppc64le-e2e-tests

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -56,7 +56,7 @@ jobs:
         value: contour.ingress.networking.knative.dev
 
   - name: ppc64le-e2e-tests
-    cron: 10 5 * * *
+    cron: 40 3 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]

--- a/prow/jobs_config/knative/serving-release-1.11.yaml
+++ b/prow/jobs_config/knative/serving-release-1.11.yaml
@@ -248,7 +248,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 10 18 * * *
+  cron: 10 16 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving

--- a/prow/jobs_config/knative/serving-release-1.12.yaml
+++ b/prow/jobs_config/knative/serving-release-1.12.yaml
@@ -238,7 +238,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 20 22 * * *
+  cron: 0 16 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving

--- a/prow/jobs_config/knative/serving-release-1.13.yaml
+++ b/prow/jobs_config/knative/serving-release-1.13.yaml
@@ -238,14 +238,14 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 40 5 * * *
+  cron: 0 10 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving
   - name: TEST_OPTIONS
     value: --enable-alpha --enable-beta --resolvabledomain=false
   - name: CI_JOB
-    value: kourier-main
+    value: kourier-release-1.13
   name: ppc64le-kourier-tests
   requirements:
   - ppc64le

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -217,7 +217,7 @@ jobs:
         value: "--enable-alpha --enable-beta --resolvabledomain=false"
 
   - name: ppc64le-kourier-tests
-    cron: 40 5 * * *
+    cron: 30 4 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]


### PR DESCRIPTION
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)

Which issue(s) this PR fixes:

Fixes

Updated the Cron job timings for ppc64le to add 1.13 release jobs


<!--
  Uncomment and fill out below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
<Explanation goes here>
-->

<!--
  If there is any golang code in this PR please uncomment the
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
