### PR TITLE
[s390x]: Moving to secure KO_DOCKRE_REPO for s390x arch

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -269,7 +269,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -425,7 +425,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -581,7 +581,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.11.gen.yaml
@@ -196,7 +196,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -352,7 +352,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -508,7 +508,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.12.gen.yaml
@@ -196,7 +196,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -278,7 +278,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -360,7 +360,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.13.gen.yaml
@@ -196,7 +196,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -278,7 +278,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -360,7 +360,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.11.gen.yaml
@@ -188,7 +188,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.12.gen.yaml
@@ -188,7 +188,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.13.gen.yaml
@@ -188,7 +188,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
@@ -78,7 +78,7 @@ periodics:
       - runner.sh
       env:
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.11.gen.yaml
@@ -153,7 +153,7 @@ periodics:
       - runner.sh
       env:
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.12.gen.yaml
@@ -153,7 +153,7 @@ periodics:
       - runner.sh
       env:
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.13.gen.yaml
@@ -153,7 +153,7 @@ periodics:
       - runner.sh
       env:
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -125,7 +125,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.11.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.12.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.13.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.11.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.12.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.13.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.11.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.12.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.13.gen.yaml
@@ -84,7 +84,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -518,7 +518,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -607,7 +607,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.11.gen.yaml
@@ -101,7 +101,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -190,7 +190,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.12.gen.yaml
@@ -101,7 +101,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -190,7 +190,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.13.gen.yaml
@@ -101,7 +101,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -190,7 +190,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x --insecure-registry
+        value: --platform=linux/s390x
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs_config/.base.yaml
+++ b/prow/jobs_config/.base.yaml
@@ -198,7 +198,7 @@ requirement_presets:
   s390x:
     env:
       - name: KO_FLAGS
-        value: "--platform=linux/s390x --insecure-registry"
+        value: "--platform=linux/s390x"
       - name: PLATFORM
         value: "linux/s390x"
       - name: KO_DOCKER_REPO


### PR DESCRIPTION
This is the PR to remove the KO_FLAG --insecure-repository. This flag when supplied along with platform flag cerating issues building the images in knative/eventing. We have moved from self-hosted registry to IBM cloud container registry hence we don't need the flag anymore.