### PR TITLE
add periodic prow job for testing serving + contour + gateway-api

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -296,16 +296,16 @@ periodics:
       name: cgroup
 - annotations:
     testgrid-dashboards: serving
-    testgrid-tab-name: gateway-api-latest
+    testgrid-tab-name: gateway-api-istio
   cluster: prow-build
-  cron: 47 */9 * * *
+  cron: 48 */9 * * *
   decorate: true
   extra_refs:
   - base_ref: main
     org: knative
     path_alias: knative.dev/serving
     repo: serving
-  name: gateway-api-latest_serving_main_periodic
+  name: gateway-api-istio_serving_main_periodic
   spec:
     containers:
     - args:
@@ -320,6 +320,65 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    serviceAccountName: test-runner
+    volumes:
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: gateway-api-contour
+  cluster: prow-build
+  cron: 22 */12 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: gateway-api-contour_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --gateway-api-version latest --gateway-api-implementation
+        contour
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240322-ec03cf0c2
       name: ""
       resources:
         limits:

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -354,10 +354,8 @@ periodics:
     testgrid-dashboards: serving
     testgrid-tab-name: gateway-api-contour
   cluster: prow-build
-  cron: 22 */12 * * *
+  cron: 22 */9 * * *
   decorate: true
-  decoration_config:
-    timeout: 3h0m0s
   extra_refs:
   - base_ref: main
     org: knative
@@ -378,7 +376,7 @@ periodics:
         value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240322-ec03cf0c2
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources:
         limits:

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -148,7 +148,7 @@ jobs:
     - --run-test
     - ./test/e2e-external-domain-tls-tests.sh --contour-version latest --run-http01-external-domain-tls-tests
 
-  - name: gateway-api-latest
+  - name: gateway-api-istio
     types: [periodic]
     command:
     - runner.sh

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -159,8 +159,6 @@ jobs:
 
   - name: gateway-api-contour
     types: [periodic]
-    timeout: 3h
-    regex: ^third_party/gateway-api-latest/*
     command:
     - runner.sh
     args:

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -157,6 +157,17 @@ jobs:
     - --run-test
     - ./test/e2e-tests.sh --gateway-api-version latest
 
+  - name: gateway-api-contour
+    types: [periodic]
+    timeout: 3h
+    regex: ^third_party/gateway-api-latest/*
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --gateway-api-version latest --gateway-api-implementation contour
+
   - name: https
     types: [periodic]
     command:


### PR DESCRIPTION
# Changes

- add periodic prow job for testing serving + contour + gateway-api
- rename periodic prow job for serving + gateway-api + istio from `gateway-api-latest` to `gateway-api-istio`

Fixes https://github.com/knative/serving/issues/14983