### PR TITLE
don't override the E2E_CLUSTER_REGION - this is defaulted in our hack scripts

### DIFF
--- a/prow/jobs/generated/knative-extensions/backstage-plugins-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/backstage-plugins-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -89,8 +87,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/backstage-plugins-release-0.1.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/backstage-plugins-release-0.1.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/discovery-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/discovery-main.gen.yaml
@@ -68,8 +68,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-autoscaler-keda-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -71,8 +69,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -177,8 +173,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kafka-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -219,8 +213,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kafka-mt-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-autoscaler-keda-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-autoscaler-keda-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -131,8 +129,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kafka-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -173,8 +169,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kafka-mt-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-autoscaler-keda-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-autoscaler-keda-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -131,8 +129,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kafka-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -173,8 +169,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kafka-mt-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-awssqs-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -71,8 +69,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-awssqs-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-awssqs-release-1.1.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-awssqs-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-awssqs-release-1.2.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-ceph-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -89,8 +87,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-ceph-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-ceph-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-ceph-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-ceph-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-couchdb-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -89,8 +87,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-couchdb-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-couchdb-release-1.0.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-couchdb-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-couchdb-release-1.1.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-github-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -89,8 +87,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-github-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-github-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-github-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-github-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-gitlab-main.gen.yaml
@@ -26,8 +26,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -93,8 +91,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-gitlab-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-gitlab-release-1.12.gen.yaml
@@ -26,8 +26,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-gitlab-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-gitlab-release-1.13.gen.yaml
@@ -26,8 +26,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-istio-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -96,8 +94,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -282,8 +278,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-istio-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-istio-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -211,8 +209,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-istio-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-istio-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -211,8 +209,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -28,8 +28,6 @@ periodics:
       env:
       - name: BROKER_CLASS
         value: Kafka
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -90,8 +88,6 @@ periodics:
       env:
       - name: BROKER_CLASS
         value: Kafka
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -163,8 +159,6 @@ periodics:
         value: Kafka
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -327,8 +321,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -406,8 +398,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -485,8 +475,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -564,8 +552,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -643,8 +629,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -722,8 +706,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -827,8 +809,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -887,8 +867,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -947,8 +925,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1007,8 +983,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: KafkaNamespaced
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1068,8 +1042,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1131,8 +1103,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1194,8 +1164,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1257,8 +1225,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_PLAIN
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1320,8 +1286,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1383,8 +1347,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1446,8 +1408,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_PLAIN
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.12.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       env:
       - name: BROKER_CLASS
         value: Kafka
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -191,8 +189,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -273,8 +269,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -355,8 +349,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -434,8 +426,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -510,8 +500,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -586,8 +574,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -691,8 +677,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -751,8 +735,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -811,8 +793,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -874,8 +854,6 @@ presubmits:
           value: Kafka
         - name: USE_LOOM
           value: "true"
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -935,8 +913,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: KafkaNamespaced
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -999,8 +975,6 @@ presubmits:
           value: KafkaNamespaced
         - name: USE_LOOM
           value: "true"
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1061,8 +1035,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1124,8 +1096,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1187,8 +1157,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1250,8 +1218,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_PLAIN
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1313,8 +1279,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1376,8 +1340,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1439,8 +1401,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_PLAIN
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.13.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       env:
       - name: BROKER_CLASS
         value: Kafka
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -191,8 +189,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -273,8 +269,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -355,8 +349,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -434,8 +426,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -510,8 +500,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -586,8 +574,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -691,8 +677,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -751,8 +735,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -811,8 +793,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -874,8 +854,6 @@ presubmits:
           value: Kafka
         - name: USE_LOOM
           value: "true"
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -935,8 +913,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: KafkaNamespaced
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -999,8 +975,6 @@ presubmits:
           value: KafkaNamespaced
         - name: USE_LOOM
           value: "true"
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1060,8 +1034,6 @@ presubmits:
         env:
         - name: BROKER_CLASS
           value: Kafka
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1123,8 +1095,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1186,8 +1156,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1249,8 +1217,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_PLAIN
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1312,8 +1278,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1375,8 +1339,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_SSL
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -1438,8 +1400,6 @@ presubmits:
           value: Kafka
         - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
           value: SASL_PLAIN
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-main.gen.yaml
@@ -193,8 +193,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --mt-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -235,8 +233,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -183,8 +181,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -333,8 +329,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --mt-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -375,8 +369,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -183,8 +181,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -333,8 +329,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --mt-source
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -375,8 +369,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kogito-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -228,8 +224,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-kogito-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kogito-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-kogito-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kogito-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-natss-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-natss-release-1.10.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-natss-release-1.10.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-natss-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-natss-release-1.4.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-rabbitmq-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-rabbitmq-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-rabbitmq-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-rabbitmq-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-rabbitmq-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-redis-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
@@ -89,8 +87,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/eventing-redis-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-redis-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/eventing-redis-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-redis-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED

--- a/prow/jobs/generated/knative-extensions/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-admin-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources: {}
@@ -241,8 +237,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-admin-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-admin-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -186,8 +184,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-admin-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-admin-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -186,8 +184,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-diag-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-diag-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -111,8 +109,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -193,8 +191,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources: {}
@@ -355,8 +351,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -300,8 +298,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -300,8 +298,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-migration-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-migration-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -111,8 +109,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-operator-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-operator-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources: {}
@@ -239,8 +235,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-operator-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-operator-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -185,8 +183,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-operator-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-operator-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -185,8 +183,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-quickstart-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources: {}
@@ -241,8 +237,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-quickstart-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-quickstart-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -186,8 +184,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-quickstart-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-quickstart-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -186,8 +184,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-sample-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-sample-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -111,8 +109,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-service-log-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-service-log-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -77,8 +75,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -274,8 +270,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-service-log-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-service-log-release-1.1.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -192,8 +190,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-source-kafka-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -277,8 +273,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-source-kafka-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-source-kafka-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -204,8 +202,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-source-kafka-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-source-kafka-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -204,8 +202,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-source-kamelet-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-source-kamelet-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources: {}
@@ -239,8 +235,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-source-kamelet-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-source-kamelet-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -185,8 +183,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/kn-plugin-source-kamelet-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-source-kamelet-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -185,8 +183,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-certmanager-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -80,8 +78,6 @@ periodics:
         value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: ATTEST_IMAGES
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -228,8 +224,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-certmanager-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-certmanager-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-certmanager-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-certmanager-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-contour-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -80,8 +78,6 @@ periodics:
         value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -228,8 +224,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-contour-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-contour-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-contour-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-contour-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-gateway-api-main.gen.yaml
@@ -26,8 +26,6 @@ periodics:
       - --run-test
       - ./test/e2e-tests.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -69,8 +67,6 @@ periodics:
       - --run-test
       - ./test/e2e-tests.sh --contour
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -122,8 +118,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -273,8 +267,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -314,8 +306,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --contour
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-gateway-api-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-gateway-api-release-1.12.gen.yaml
@@ -134,8 +134,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --contour
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-gateway-api-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-gateway-api-release-1.13.gen.yaml
@@ -134,8 +134,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --contour
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-http01-main.gen.yaml
@@ -131,8 +131,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-http01-release-1.11.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-http01-release-1.11.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-http01-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-http01-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-istio-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -228,8 +224,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -268,8 +262,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -308,8 +300,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest  --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-istio-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-istio-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -215,8 +211,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -255,8 +249,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest  --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-istio-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-istio-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -215,8 +211,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -255,8 +249,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest  --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-kourier-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -78,8 +76,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -228,8 +224,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-kourier-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-kourier-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/net-kourier-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/net-kourier-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/reconciler-test-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/reconciler-test-main.gen.yaml
@@ -68,8 +68,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/sample-controller-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/sample-controller-main.gen.yaml
@@ -28,8 +28,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/sample-source-main.gen.yaml
@@ -29,8 +29,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative-extensions/security-guard-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/security-guard-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -71,8 +69,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -221,8 +217,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/security-guard-release-0.5.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/security-guard-release-0.5.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/security-guard-release-0.6.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/security-guard-release-0.6.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/serving-progressive-rollout-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/serving-progressive-rollout-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -71,8 +69,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -221,8 +217,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative-extensions/serving-progressive-rollout-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/serving-progressive-rollout-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -175,8 +173,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/caching-main.gen.yaml
+++ b/prow/jobs/generated/knative/caching-main.gen.yaml
@@ -68,8 +68,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -66,8 +64,6 @@ periodics:
       - runner.sh
       - ./test/tekton-tests.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -120,8 +116,6 @@ periodics:
       env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -191,8 +185,6 @@ periodics:
         value: client-main
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -269,8 +261,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources: {}
@@ -327,8 +317,6 @@ periodics:
       - --apple-codesign-password-file
       - /etc/notary/password
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -429,8 +417,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -467,8 +453,6 @@ presubmits:
         - runner.sh
         - ./test/presubmit-integration-tests-latest-release.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/client-pkg-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-pkg-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/client-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
       env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -150,8 +146,6 @@ periodics:
         value: client-release-1.12
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -224,8 +218,6 @@ periodics:
       - --branch
       - release-1.12
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -326,8 +318,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -364,8 +354,6 @@ presubmits:
         - runner.sh
         - ./test/presubmit-integration-tests-latest-release.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/client-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
       env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -150,8 +146,6 @@ periodics:
         value: client-release-1.13
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -224,8 +218,6 @@ periodics:
       - --branch
       - release-1.13
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -326,8 +318,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -364,8 +354,6 @@ presubmits:
         - runner.sh
         - ./test/presubmit-integration-tests-latest-release.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -87,8 +85,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -167,8 +163,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -244,8 +238,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -318,8 +310,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -394,8 +384,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -453,8 +441,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -563,8 +549,6 @@ presubmits:
         - --run-test
         - ./test/e2e-conformance-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -607,8 +591,6 @@ presubmits:
         - --run-test
         - ./test/e2e-rekt-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -651,8 +633,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/eventing-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.12.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -87,8 +85,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -167,8 +163,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -244,8 +238,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -318,8 +310,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -394,8 +384,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -504,8 +492,6 @@ presubmits:
         - --run-test
         - ./test/e2e-conformance-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -548,8 +534,6 @@ presubmits:
         - --run-test
         - ./test/e2e-rekt-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -592,8 +576,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/eventing-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.13.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -87,8 +85,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -167,8 +163,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -244,8 +238,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -318,8 +310,6 @@ periodics:
         value: "1"
       - name: SYSTEM_NAMESPACE
         value: knative-eventing
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -394,8 +384,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -504,8 +492,6 @@ presubmits:
         - --run-test
         - ./test/e2e-conformance-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -548,8 +534,6 @@ presubmits:
         - --run-test
         - ./test/e2e-rekt-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -592,8 +576,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/func-main.gen.yaml
+++ b/prow/jobs/generated/knative/func-main.gen.yaml
@@ -44,8 +44,6 @@ periodics:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -120,8 +118,6 @@ periodics:
       - --apple-codesign-password-file
       - /etc/notary/password
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative/func-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/func-release-1.12.gen.yaml
@@ -40,8 +40,6 @@ periodics:
       - --branch
       - release-1.12
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative/func-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/func-release-1.13.gen.yaml
@@ -40,8 +40,6 @@ periodics:
       - --branch
       - release-1.13
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES

--- a/prow/jobs/generated/knative/hack-main.gen.yaml
+++ b/prow/jobs/generated/knative/hack-main.gen.yaml
@@ -44,9 +44,6 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
         name: ""
         resources: {}
@@ -72,8 +69,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/networking-main.gen.yaml
+++ b/prow/jobs/generated/knative/networking-main.gen.yaml
@@ -68,8 +68,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
       env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -150,8 +146,6 @@ periodics:
         value: operator-main
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -220,8 +214,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -273,8 +265,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -370,8 +360,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -410,8 +398,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -450,8 +436,6 @@ presubmits:
         - --run-test
         - ./test/e2e-serving-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -491,8 +475,6 @@ presubmits:
         - --run-test
         - ./test/e2e-eventing-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/operator-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.12.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
       env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -150,8 +146,6 @@ periodics:
         value: operator-release-1.12
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -220,8 +214,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -317,8 +309,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -357,8 +347,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -397,8 +385,6 @@ presubmits:
         - --run-test
         - ./test/e2e-serving-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -438,8 +424,6 @@ presubmits:
         - --run-test
         - ./test/e2e-eventing-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/operator-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.13.gen.yaml
@@ -25,8 +25,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -79,8 +77,6 @@ periodics:
       env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -150,8 +146,6 @@ periodics:
         value: operator-release-1.13
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
@@ -220,8 +214,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -317,8 +309,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -357,8 +347,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -397,8 +385,6 @@ presubmits:
         - --run-test
         - ./test/e2e-serving-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -438,8 +424,6 @@ presubmits:
         - --run-test
         - ./test/e2e-eventing-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/pkg-main.gen.yaml
+++ b/prow/jobs/generated/knative/pkg-main.gen.yaml
@@ -68,8 +68,6 @@ presubmits:
         - ./test/presubmit-tests.sh
         - --integration-tests
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -85,8 +83,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -143,8 +139,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -201,8 +195,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -259,8 +251,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -315,8 +305,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -372,8 +360,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -430,8 +416,6 @@ periodics:
       command:
       - runner.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -487,8 +471,6 @@ periodics:
       - --run-test
       - ./test/performance/performance-tests.sh
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -570,8 +552,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -659,8 +639,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -745,8 +723,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -829,8 +805,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: SIGN_IMAGES
@@ -907,8 +881,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -1073,8 +1045,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1125,8 +1095,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --no-mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1178,8 +1146,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --no-mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1234,8 +1200,6 @@ presubmits:
         - --run-test
         - ./test/performance/performance-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1301,8 +1265,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1354,8 +1316,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --mesh --short
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1408,8 +1368,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1462,8 +1420,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kourier-version stable
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1515,8 +1471,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --kourier-version stable
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1568,8 +1522,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --contour-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1621,8 +1573,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --contour-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1674,8 +1624,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --gateway-api-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1729,8 +1677,6 @@ presubmits:
         - ./test/e2e-tests.sh --gateway-api-version latest --gateway-api-implementation
           contour
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1787,8 +1733,6 @@ presubmits:
         command:
         - runner.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/serving-release-1.12.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.12.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -96,8 +94,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -185,8 +181,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -271,8 +265,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -355,8 +347,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
       name: ""
       resources:
@@ -517,8 +507,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -569,8 +557,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --no-mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -622,8 +608,6 @@ presubmits:
         - --run-test
         - ./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -678,8 +662,6 @@ presubmits:
         - --run-test
         - ./test/performance/performance-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -745,8 +727,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -798,8 +778,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --mesh --short
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -852,8 +830,6 @@ presubmits:
         - --run-test
         - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -906,8 +882,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kourier-version stable
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -959,8 +933,6 @@ presubmits:
         - --run-test
         - ./test/e2e-auto-tls-tests.sh --kourier-version stable
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1012,8 +984,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --contour-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1065,8 +1035,6 @@ presubmits:
         - --run-test
         - ./test/e2e-auto-tls-tests.sh --contour-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1118,8 +1086,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --gateway-api-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1175,8 +1141,6 @@ presubmits:
         command:
         - runner.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs/generated/knative/serving-release-1.13.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.13.gen.yaml
@@ -27,8 +27,6 @@ periodics:
       - ./test/presubmit-tests.sh
       - --all-tests
       env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -96,8 +94,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -185,8 +181,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -271,8 +265,6 @@ periodics:
         value: knative-serving
       - name: TEST_OPTIONS
         value: --enable-alpha --enable-beta --resolvabledomain=false
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
@@ -355,8 +347,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -521,8 +511,6 @@ presubmits:
         - --run-test
         - ./test/e2e-upgrade-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -573,8 +561,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --no-mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -626,8 +612,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --no-mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -682,8 +666,6 @@ presubmits:
         - --run-test
         - ./test/performance/performance-tests.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -749,8 +731,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -802,8 +782,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --istio-version latest --mesh --short
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -856,8 +834,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --mesh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -910,8 +886,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --kourier-version stable
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -963,8 +937,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --kourier-version stable
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1016,8 +988,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --contour-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1069,8 +1039,6 @@ presubmits:
         - --run-test
         - ./test/e2e-external-domain-tls-tests.sh --contour-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1122,8 +1090,6 @@ presubmits:
         - --run-test
         - ./test/e2e-tests.sh --gateway-api-version latest
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5
@@ -1179,8 +1145,6 @@ presubmits:
         command:
         - runner.sh
         env:
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
         image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240327-0a7207ad5

--- a/prow/jobs_config/.base.yaml
+++ b/prow/jobs_config/.base.yaml
@@ -21,8 +21,6 @@ requirement_presets:
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -47,8 +45,6 @@ requirement_presets:
         value: "true"
       - name: ATTEST_IMAGES
         value: "true"
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
     volumeMounts:
       - name: apple-notary-creds
         mountPath: /etc/notary
@@ -69,8 +65,6 @@ requirement_presets:
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -100,8 +94,6 @@ requirement_presets:
     podSpec:
       serviceAccountName: release
     env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -158,8 +150,6 @@ requirement_presets:
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
     volumeMounts:
       - name: influx-token-secret-volume
         mountPath: /etc/influx-token-secret-volume
@@ -179,8 +169,6 @@ requirement_presets:
 
   gcp:
     env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
     volumeMounts:

--- a/prow/jobs_config/knative/hack.yaml
+++ b/prow/jobs_config/knative/hack.yaml
@@ -13,9 +13,6 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --unit-tests]
     excluded_requirements: [gcp]
-    env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
 
   - name: integration-tests
     types: [presubmit]

--- a/prow/jobs_config/knative/serving-release-1.12.yaml
+++ b/prow/jobs_config/knative/serving-release-1.12.yaml
@@ -276,16 +276,11 @@ org: knative
 repo: serving
 requirement_presets:
   gcp:
-    env:
-    - name: E2E_CLUSTER_REGION
-      value: us-central1
     podSpec:
       containers: null
       serviceAccountName: test-runner
   nightly:
     env:
-    - name: E2E_CLUSTER_REGION
-      value: us-central1
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /etc/nightly-account/service-account.json
     podSpec:
@@ -323,9 +318,6 @@ requirement_presets:
         defaultMode: 384
         secretName: influx-url-secret
   release:
-    env:
-    - name: E2E_CLUSTER_REGION
-      value: us-central1
     podSpec:
       containers: null
       serviceAccountName: release

--- a/prow/jobs_config/knative/serving-release-1.13.yaml
+++ b/prow/jobs_config/knative/serving-release-1.13.yaml
@@ -276,16 +276,11 @@ org: knative
 repo: serving
 requirement_presets:
   gcp:
-    env:
-    - name: E2E_CLUSTER_REGION
-      value: us-central1
     podSpec:
       containers: null
       serviceAccountName: test-runner
   nightly:
     env:
-    - name: E2E_CLUSTER_REGION
-      value: us-central1
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /etc/nightly-account/service-account.json
     - name: SIGN_IMAGES
@@ -328,8 +323,6 @@ requirement_presets:
         secretName: influx-url-secret
   release:
     env:
-    - name: E2E_CLUSTER_REGION
-      value: us-central1
     - name: SIGN_IMAGES
       value: "true"
     - name: ATTEST_IMAGES

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -294,8 +294,6 @@ requirement_presets:
     podSpec:
       serviceAccountName: nightly
     env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: SIGN_IMAGES
@@ -318,8 +316,6 @@ requirement_presets:
     podSpec:
       serviceAccountName: release
     env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
       - name: SIGN_IMAGES
         value: "true"
       - name: ATTEST_IMAGES
@@ -364,6 +360,3 @@ requirement_presets:
   gcp:
     podSpec:
       serviceAccountName: test-runner
-    env:
-      - name: E2E_CLUSTER_REGION
-        value: us-central1


### PR DESCRIPTION
Clusters are failing to start again like before - https://github.com/knative/serving/issues/14935

I thought we changed the region by changing the hack scripts (https://github.com/knative/serving/issues/14935#issuecomment-1994419996) but we didn't because it's overriden in the prow job config.