### PR TITLE
Fix consistentimageexceptions

### DIFF
--- a/prow/autobump-config/knative.yaml
+++ b/prow/autobump-config/knative.yaml
@@ -24,6 +24,17 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: true
+    consistentImageExceptions:
+      - "gcr.io/k8s-prow/alpine"
+      - "gcr.io/k8s-prow/analyze"
+      - "gcr.io/k8s-prow/commenter"
+      - "gcr.io/k8s-prow/configurator"
+      - "gcr.io/k8s-prow/gcsweb"
+      - "gcr.io/k8s-prow/gencred"
+      - "gcr.io/k8s-prow/git"
+      - "gcr.io/k8s-prow/issue-creator"
+      - "gcr.io/k8s-prow/label_sync"
+      - "gcr.io/k8s-prow/pr-creator"
   - name: "Boskos"
     prefix: "gcr.io/k8s-staging-boskos/"
     refConfigFile: "config/prow/cluster/build/boskos.yaml"


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/31728#issuecomment-2048438546

https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-prow-auto-bumper-for-auto-deploy/1782428045601148928

We don't release the images any more with the same hashes(some like in k/test-infra and prow lives in k-sigs/prow).

/cc @cardil 