### PR TITLE
[ppc64le]: add ppc64le specific prow job config for release-1.14

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-release-1.14.gen.yaml
@@ -390,6 +390,228 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-extensions-release-1.14
+    testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-ssl
+  cluster: prow-build
+  cron: 40 11 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative-extensions
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: ppc64le-e2e-tests-ssl_eventing-kafka-broker_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: BROKER_CLASS
+        value: Kafka
+      - name: CI_JOB
+        value: eventing_kafka-broker-ssl-114
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SSL
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: knative-extensions-release-1.14
+    testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-sasl-ssl
+  cluster: prow-build
+  cron: 10 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative-extensions
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: ppc64le-e2e-tests-sasl-ssl_eventing-kafka-broker_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: BROKER_CLASS
+        value: Kafka
+      - name: CI_JOB
+        value: eventing_kafka-broker-sasl-ssl-114
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_SSL
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: knative-extensions-release-1.14
+    testgrid-tab-name: eventing-kafka-broker-ppc64le-e2e-tests-sasl-plain
+  cluster: prow-build
+  cron: 20 2 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative-extensions
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: ppc64le-e2e-tests-sasl-plain_eventing-kafka-broker_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: BROKER_CLASS
+        value: Kafka
+      - name: CI_JOB
+        value: eventing_kafka-broker-sasl-plain-114
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_PLAIN
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative-extensions/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.14.gen.yaml
@@ -150,6 +150,8 @@ periodics:
       command:
       - runner.sh
       env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
       - name: KO_FLAGS
         value: --platform=linux/s390x
       - name: PLATFORM
@@ -169,6 +171,9 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
       - mountPath: /opt/cluster
         name: s390x-cluster1
         readOnly: true
@@ -176,10 +181,71 @@ periodics:
       kubernetes.io/arch: amd64
       type: testing
     volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - name: s390x-cluster1
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-extensions-release-1.14
+    testgrid-tab-name: kn-plugin-event-ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 40 14 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative-extensions
+    path_alias: knative.dev/kn-plugin-event
+    repo: kn-plugin-event
+  name: ppc64le-e2e-tests_kn-plugin-event_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: plugin_event-114
+      - name: SSL_CERT_FILE
+        value: /tmp/ssl.crt
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative-extensions/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative/client-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.14.gen.yaml
@@ -189,6 +189,72 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.14
+    testgrid-tab-name: client-ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 50 12 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: ppc64le-e2e-tests_client_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: client-release-1.14
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/client:
   - always_run: true

--- a/prow/jobs/generated/knative/eventing-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.14.gen.yaml
@@ -276,6 +276,150 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.14
+    testgrid-tab-name: eventing-ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 40 13 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-tests_eventing_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: eventing-release-1.14
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: knative-release-1.14
+    testgrid-tab-name: eventing-ppc64le-e2e-reconciler-tests
+  cluster: prow-build
+  cron: 10 12 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-reconciler-tests_eventing_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-rekt-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: eventing_rekt-114
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/eventing:
   - always_run: true

--- a/prow/jobs/generated/knative/operator-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.14.gen.yaml
@@ -180,6 +180,72 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.14
+    testgrid-tab-name: operator-ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 0 14 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative
+    path_alias: knative.dev/operator
+    repo: operator
+  name: ppc64le-e2e-tests_operator_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: operator-release-1.14
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/operator:
   - always_run: true

--- a/prow/jobs/generated/knative/serving-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.14.gen.yaml
@@ -316,6 +316,87 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.14
+    testgrid-tab-name: serving-ppc64le-kourier-tests
+  cluster: prow-build
+  cron: 50 14 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.14
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: ppc64le-kourier-tests_serving_release-1.14_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+        ./test/e2e-tests.sh --run-tests --kourier-version latest
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: kourier-release-1.14
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: --enable-alpha --enable-beta --resolvabledomain=false
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240417-d0a9ee0eb
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    serviceAccountName: test-runner
+    volumes:
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/serving:
   - always_run: true

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker-release-1.14.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker-release-1.14.yaml
@@ -300,6 +300,81 @@ jobs:
       value: SASL_PLAIN
     - name: BROKER_CLASS
       value: Kafka
+- name: ppc64le-e2e-tests-ssl
+  cron: 40 11 * * *
+  types: [periodic]
+  requirements: [ppc64le]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      server_vm="$(sh /opt/cluster/vm-script)"
+      source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: CI_JOB
+      value: eventing_kafka-broker-ssl-114
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
+    - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+      value: SSL
+    - name: BROKER_CLASS
+      value: Kafka
+- name: ppc64le-e2e-tests-sasl-ssl
+  cron: 10 7 * * *
+  types: [periodic]
+  requirements: [ppc64le]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      server_vm="$(sh /opt/cluster/vm-script)"
+      source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: CI_JOB
+      value: eventing_kafka-broker-sasl-ssl-114
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
+    - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+      value: SASL_SSL
+    - name: BROKER_CLASS
+      value: Kafka
+- name: ppc64le-e2e-tests-sasl-plain
+  cron: 20 2 * * *
+  types: [periodic]
+  requirements: [ppc64le]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      server_vm="$(sh /opt/cluster/vm-script)"
+      source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: CI_JOB
+      value: eventing_kafka-broker-sasl-plain-114
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
+    - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+      value: SASL_PLAIN
+    - name: BROKER_CLASS
+      value: Kafka
 
 org: knative-extensions
 repo: eventing-kafka-broker

--- a/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.14.yaml
+++ b/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.14.yaml
@@ -86,6 +86,26 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  env:
+  - name: CI_JOB
+    value: plugin_event-114
+  - name: SSL_CERT_FILE
+    value: /tmp/ssl.crt
+  command:
+  - runner.sh
+  cron: 40 14 * * *
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
   excluded_requirements:
   - gcp
 org: knative-extensions

--- a/prow/jobs_config/knative/client-release-1.14.yaml
+++ b/prow/jobs_config/knative/client-release-1.14.yaml
@@ -96,5 +96,25 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 50 12 * * *
+  env:
+  - name: CI_JOB
+    value: client-release-1.14
+  - name: INGRESS_CLASS
+    value: contour.ingress.networking.knative.dev
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: client

--- a/prow/jobs_config/knative/eventing-release-1.14.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.14.yaml
@@ -130,6 +130,50 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 40 13 * * *
+  env:
+  - name: SYSTEM_NAMESPACE
+    value: knative-eventing
+  - name: SCALE_CHAOSDUCK_TO_ZERO
+    value: "1"
+  - name: CI_JOB
+    value: eventing-release-1.14
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-rekt-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 10 12 * * *
+  env:
+  - name: SYSTEM_NAMESPACE
+    value: knative-eventing
+  - name: SCALE_CHAOSDUCK_TO_ZERO
+    value: "1"
+  - name: CI_JOB
+    value: eventing_rekt-114
+  name: ppc64le-e2e-reconciler-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: eventing
 resources: high

--- a/prow/jobs_config/knative/operator-release-1.14.yaml
+++ b/prow/jobs_config/knative/operator-release-1.14.yaml
@@ -107,5 +107,25 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 0 14 * * *
+  env:
+  - name: CI_JOB
+    value: operator-release-1.14
+  - name: INGRESS_CLASS
+    value: contour.ingress.networking.knative.dev
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: operator

--- a/prow/jobs_config/knative/serving-release-1.14.yaml
+++ b/prow/jobs_config/knative/serving-release-1.14.yaml
@@ -262,6 +262,29 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+    ./test/e2e-tests.sh --run-tests --kourier-version latest
+  command:
+  - runner.sh
+  cron: 50 14 * * *
+  env:
+  - name: SYSTEM_NAMESPACE
+    value: knative-serving
+  - name: TEST_OPTIONS
+    value: --enable-alpha --enable-beta --resolvabledomain=false
+  - name: CI_JOB
+    value: kourier-release-1.14
+  name: ppc64le-kourier-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: serving
 requirement_presets:


### PR DESCRIPTION
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)

Which issue(s) this PR fixes:

Fixes

PR to add release 1.14 jobs on ppc64le