### PR TITLE
Fix istio no-mesh build command

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -133,9 +133,9 @@ periodics:
     - args:
       - ./test/presubmit-tests.sh
       - --run-test
-      - ./test/e2e-tests.sh --istio-version latest --mesh
+      - ./test/e2e-tests.sh --istio-version latest --no-mesh
       - --run-test
-      - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --mesh
+      - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --no-mesh
       command:
       - runner.sh
       env:

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -122,9 +122,9 @@ jobs:
     args:
     - ./test/presubmit-tests.sh
     - --run-test
-    - ./test/e2e-tests.sh --istio-version latest --mesh
+    - ./test/e2e-tests.sh --istio-version latest --no-mesh
     - --run-test
-    - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --mesh
+    - ./test/e2e-external-domain-tls-tests.sh --istio-version latest --no-mesh
 
   - name: kourier-stable
     types: [periodic]


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes https://github.com/knative/serving/issues/15274

**What this PR does, why we need it**:
- Fixes istio build config (no-mesh build should have --no-mesh)
