### PR TITLE
[ppc64le]: Updated job config for release-1.15 for ppc64le

### DIFF
--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-main.gen.yaml
@@ -131,6 +131,8 @@ periodics:
       env:
       - name: CI_JOB
         value: plugin_event-main
+      - name: KO_DEFAULTBASEIMAGE
+        value: gcr.io/distroless/static:nonroot
       - name: SSL_CERT_FILE
         value: /tmp/ssl.crt
       - name: KO_FLAGS

--- a/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/kn-plugin-event-release-1.14.gen.yaml
@@ -217,6 +217,8 @@ periodics:
       env:
       - name: CI_JOB
         value: plugin_event-114
+      - name: KO_DEFAULTBASEIMAGE
+        value: gcr.io/distroless/static:nonroot
       - name: SSL_CERT_FILE
         value: /tmp/ssl.crt
       - name: KO_FLAGS

--- a/prow/jobs/generated/knative/client-release-1.15.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.15.gen.yaml
@@ -189,6 +189,72 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.15
+    testgrid-tab-name: client-ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 40 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.15
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: ppc64le-e2e-tests_client_release-1.15_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: client-release-1.15
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240729-fb7cfc68e
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/client:
   - always_run: true

--- a/prow/jobs/generated/knative/eventing-release-1.15.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.15.gen.yaml
@@ -276,6 +276,150 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.15
+    testgrid-tab-name: eventing-ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 20 8 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.15
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-tests_eventing_release-1.15_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: eventing-release-1.15
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240729-fb7cfc68e
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: knative-release-1.15
+    testgrid-tab-name: eventing-ppc64le-e2e-reconciler-tests
+  cluster: prow-build
+  cron: 10 6 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.15
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-reconciler-tests_eventing_release-1.15_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        ./test/e2e-rekt-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: eventing_rekt-115
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240729-fb7cfc68e
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/eventing:
   - always_run: true

--- a/prow/jobs/generated/knative/operator-release-1.15.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.15.gen.yaml
@@ -180,6 +180,68 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+postsubmits:
+  knative/operator:
+  - branches:
+    - ^release-1.15$
+    cluster: prow-build
+    decorate: true
+    name: ppc64le-e2e-tests_operator_release-1.15_postsubmit
+    path_alias: knative.dev/operator
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          server_vm="$(sh /opt/cluster/vm-script)"
+          source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+          ./test/e2e-tests.sh --run-tests
+        command:
+        - runner.sh
+        env:
+        - name: CI_JOB
+          value: operator-release-1.15
+        - name: INGRESS_CLASS
+          value: contour.ingress.networking.knative.dev
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: KO_FLAGS
+          value: --platform=linux/ppc64le
+        - name: PLATFORM
+          value: linux/ppc64le
+        - name: KO_DOCKER_REPO
+          value: icr.io/upstream-k8s-registry/knative
+        - name: KUBECONFIG
+          value: /root/.kube/config
+        - name: DOCKER_CONFIG
+          value: /opt/cluster
+        image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240729-fb7cfc68e
+        name: ""
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/test-account
+          name: test-account
+          readOnly: true
+        - mountPath: /opt/cluster
+          name: ppc64le-cluster
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        type: testing
+      volumes:
+      - name: test-account
+        secret:
+          items:
+          - key: service-account-key.json
+            path: service-account.json
+          secretName: prow-google-credentials
+      - name: ppc64le-cluster
+        secret:
+          defaultMode: 384
+          secretName: ppc64le-cluster
 presubmits:
   knative/operator:
   - always_run: true
@@ -381,3 +443,66 @@ presubmits:
           secretName: prow-google-credentials
     trigger: ((?m)^/test( | .* )eventing-upgrade-tests,?($|\s.*))|((?m)^/test( | .*
       )eventing-upgrade-tests_operator_release-1.15,?($|\s.*))
+  - always_run: true
+    branches:
+    - ^release-1.15$
+    cluster: prow-build
+    decorate: true
+    name: ppc64le-e2e-tests_operator_release-1.15
+    path_alias: knative.dev/operator
+    rerun_command: /test ppc64le-e2e-tests
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          server_vm="$(sh /opt/cluster/vm-script)"
+          source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+          ./test/e2e-tests.sh --run-tests
+        command:
+        - runner.sh
+        env:
+        - name: CI_JOB
+          value: operator-release-1.15
+        - name: INGRESS_CLASS
+          value: contour.ingress.networking.knative.dev
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: KO_FLAGS
+          value: --platform=linux/ppc64le
+        - name: PLATFORM
+          value: linux/ppc64le
+        - name: KO_DOCKER_REPO
+          value: icr.io/upstream-k8s-registry/knative
+        - name: KUBECONFIG
+          value: /root/.kube/config
+        - name: DOCKER_CONFIG
+          value: /opt/cluster
+        image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240729-fb7cfc68e
+        name: ""
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/test-account
+          name: test-account
+          readOnly: true
+        - mountPath: /opt/cluster
+          name: ppc64le-cluster
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        type: testing
+      volumes:
+      - name: test-account
+        secret:
+          items:
+          - key: service-account-key.json
+            path: service-account.json
+          secretName: prow-google-credentials
+      - name: ppc64le-cluster
+        secret:
+          defaultMode: 384
+          secretName: ppc64le-cluster
+    trigger: ((?m)^/test( | .* )ppc64le-e2e-tests,?($|\s.*))|((?m)^/test( | .* )ppc64le-e2e-tests_operator_release-1.15,?($|\s.*))

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -627,6 +627,7 @@ periodics:
         server_vm="$(sh /opt/cluster/vm-script)"
         source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
         export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+        export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
         ./test/e2e-tests.sh --run-tests --kourier-version latest
       command:
       - runner.sh

--- a/prow/jobs/generated/knative/serving-release-1.14.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.14.gen.yaml
@@ -251,6 +251,7 @@ periodics:
         server_vm="$(sh /opt/cluster/vm-script)"
         source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
         export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+        export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
         ./test/e2e-tests.sh --run-tests --kourier-version latest
       command:
       - runner.sh

--- a/prow/jobs/generated/knative/serving-release-1.15.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.15.gen.yaml
@@ -230,6 +230,88 @@ periodics:
       secret:
         defaultMode: 384
         secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-release-1.15
+    testgrid-tab-name: serving-ppc64le-kourier-tests
+  cluster: prow-build
+  cron: 20 10 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.15
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: ppc64le-kourier-tests_serving_release-1.15_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        server_vm="$(sh /opt/cluster/vm-script)"
+        source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+        export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
+        ./test/e2e-tests.sh --run-tests --kourier-version latest
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: kourier-release-1.15
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: --enable-alpha --enable-beta --resolvabledomain=false
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: icr.io/upstream-k8s-registry/knative
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20240729-fb7cfc68e
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    serviceAccountName: test-runner
+    volumes:
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
 presubmits:
   knative/serving:
   - always_run: true

--- a/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.14.yaml
+++ b/prow/jobs_config/knative-extensions/kn-plugin-event-release-1.14.yaml
@@ -98,6 +98,8 @@ jobs:
     value: plugin_event-114
   - name: SSL_CERT_FILE
     value: /tmp/ssl.crt
+  - name: KO_DEFAULTBASEIMAGE
+    value: gcr.io/distroless/static:nonroot
   command:
   - runner.sh
   cron: 40 14 * * *

--- a/prow/jobs_config/knative-extensions/kn-plugin-event.yaml
+++ b/prow/jobs_config/knative-extensions/kn-plugin-event.yaml
@@ -56,7 +56,9 @@ jobs:
     - name: CI_JOB
       value: plugin_event-main
     - name: SSL_CERT_FILE
-      VALUE: /tmp/ssl.crt
+      value: /tmp/ssl.crt
+    - name: KO_DEFAULTBASEIMAGE
+      value: gcr.io/distroless/static:nonroot
     excluded_requirements:
     - gcp
   - name: nightly

--- a/prow/jobs_config/knative/client-release-1.15.yaml
+++ b/prow/jobs_config/knative/client-release-1.15.yaml
@@ -96,5 +96,25 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 40 7 * * *
+  env:
+  - name: CI_JOB
+    value: client-release-1.15
+  - name: INGRESS_CLASS
+    value: contour.ingress.networking.knative.dev
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: client

--- a/prow/jobs_config/knative/eventing-release-1.15.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.15.yaml
@@ -130,6 +130,50 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 20 8 * * *
+  env:
+  - name: SYSTEM_NAMESPACE
+    value: knative-eventing
+  - name: SCALE_CHAOSDUCK_TO_ZERO
+    value: "1"
+  - name: CI_JOB
+    value: eventing-release-1.15
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-rekt-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 10 6 * * *
+  env:
+  - name: SYSTEM_NAMESPACE
+    value: knative-eventing
+  - name: SCALE_CHAOSDUCK_TO_ZERO
+    value: "1"
+  - name: CI_JOB
+    value: eventing_rekt-115
+  name: ppc64le-e2e-reconciler-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: eventing
 resources: high

--- a/prow/jobs_config/knative/operator-release-1.15.yaml
+++ b/prow/jobs_config/knative/operator-release-1.15.yaml
@@ -107,5 +107,23 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    ./test/e2e-tests.sh --run-tests
+  command:
+  - runner.sh
+  cron: 40 9 * * *
+  env:
+  - name: CI_JOB
+    value: operator-release-1.15
+  - name: INGRESS_CLASS
+    value: contour.ingress.networking.knative.dev
+  name: ppc64le-e2e-tests
+  requirements:
+  - ppc64le
 org: knative
 repo: operator

--- a/prow/jobs_config/knative/serving-release-1.14.yaml
+++ b/prow/jobs_config/knative/serving-release-1.14.yaml
@@ -244,6 +244,7 @@ jobs:
     server_vm="$(sh /opt/cluster/vm-script)"
     source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
     export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+    export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh

--- a/prow/jobs_config/knative/serving-release-1.15.yaml
+++ b/prow/jobs_config/knative/serving-release-1.15.yaml
@@ -237,6 +237,30 @@ jobs:
   - s390x
   types:
   - periodic
+- args:
+  - bash
+  - -c
+  - |
+    server_vm="$(sh /opt/cluster/vm-script)"
+    source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
+    export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+    export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
+    ./test/e2e-tests.sh --run-tests --kourier-version latest
+  command:
+  - runner.sh
+  cron: 20 10 * * *
+  env:
+  - name: SYSTEM_NAMESPACE
+    value: knative-serving
+  - name: TEST_OPTIONS
+    value: --enable-alpha --enable-beta --resolvabledomain=false
+  - name: CI_JOB
+    value: kourier-release-1.15
+  name: ppc64le-kourier-tests
+  requirements:
+  - ppc64le
+  types:
+  - periodic
 org: knative
 repo: serving
 requirement_presets:

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -220,6 +220,7 @@ jobs:
         server_vm="$(sh /opt/cluster/vm-script)"
         source /opt/cluster/ci-script "${CI_JOB}" "${server_vm}"
         export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_vm}
+        export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
         ./test/e2e-tests.sh --run-tests --kourier-version latest
     env:
       - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)
<!--
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
-->
**Which issue(s) this PR fixes**:<br>

This PR updates the ppc64le specific job config for release 1.15 for operator, client, serving, eventing and eventing-reconciler and fixes the chainguard image issue for ppc64le. 



<!--
  Uncomment and fill out below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
<Explanation goes here>
-->

<!--
  If there is any golang code in this PR please uncomment the
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
