### PR TITLE
switch to the new prow image registry

### DIFF
--- a/prow/autobump-config/knative.yaml
+++ b/prow/autobump-config/knative.yaml
@@ -7,8 +7,7 @@ gitHubOrg: "knative"
 gitHubRepo: "infra"
 remoteName: "infra"
 headBranchName: "autobump-knative"
-upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
-targetVersion: "upstream"
+targetVersion: "latest"
 includedConfigPaths:
   - "prow/cluster/control-plane"
   - "prow/cluster/build"
@@ -19,25 +18,12 @@ extraFiles:
   - "prow/jobs/run_job.sh"
 prefixes:
   - name: "Prow"
-    prefix: "gcr.io/k8s-prow/"
-    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
-    repo: "https://github.com/kubernetes/test-infra"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
+    repo: "https://github.com/kubernetes-sigs/prow"
     summarise: false
     consistentImages: true
-    consistentImageExceptions:
-      - "gcr.io/k8s-prow/alpine"
-      - "gcr.io/k8s-prow/analyze"
-      - "gcr.io/k8s-prow/commenter"
-      - "gcr.io/k8s-prow/configurator"
-      - "gcr.io/k8s-prow/gcsweb"
-      - "gcr.io/k8s-prow/gencred"
-      - "gcr.io/k8s-prow/git"
-      - "gcr.io/k8s-prow/issue-creator"
-      - "gcr.io/k8s-prow/label_sync"
-      - "gcr.io/k8s-prow/pr-creator"
   - name: "Boskos"
     prefix: "gcr.io/k8s-staging-boskos/"
-    refConfigFile: "config/prow/cluster/build/boskos.yaml"
     repo: "https://github.com/kubernetes-sigs/boskos"
     summarise: false
     consistentImages: true

--- a/prow/cluster/control-plane/400-crier.yaml
+++ b/prow/cluster/control-plane/400-crier.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240802-66b115076
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --blob-storage-workers=1

--- a/prow/cluster/control-plane/400-deck.yaml
+++ b/prow/cluster/control-plane/400-deck.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240802-66b115076
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/

--- a/prow/cluster/control-plane/400-ghproxy.yaml
+++ b/prow/cluster/control-plane/400-ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20240802-66b115076
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240802-66b115076
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/prow/cluster/control-plane/400-hook.yaml
+++ b/prow/cluster/control-plane/400-hook.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/control-plane/400-horologium.yaml
+++ b/prow/cluster/control-plane/400-horologium.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/cluster/control-plane/400-prow-controller-manager.yaml
+++ b/prow/cluster/control-plane/400-prow-controller-manager.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/control-plane/400-sinker.yaml
+++ b/prow/cluster/control-plane/400-sinker.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/cluster/control-plane/400-tide.yaml
+++ b/prow/cluster/control-plane/400-tide.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/cluster/control-plane/500-cherrypicker.yaml
+++ b/prow/cluster/control-plane/500-cherrypicker.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20240802-66b115076
         args:
         - --dry-run=false
         - --use-prow-assignments=false

--- a/prow/cluster/control-plane/500-needs-rebase.yaml
+++ b/prow/cluster/control-plane/500-needs-rebase.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/control-plane/500-status-reconciler.yaml
+++ b/prow/cluster/control-plane/500-status-reconciler.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20240802-66b115076
+          image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240802-66b115076
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/trusted/ghproxy.yaml
+++ b/prow/cluster/trusted/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20240802-66b115076
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240802-66b115076
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -25,10 +25,10 @@ plank:
         grace_period: 15s
         utility_images:
           # Update these versions when updating plank version in cluster.yaml
-          clonerefs: "gcr.io/k8s-prow/clonerefs:v20240802-66b115076"
-          initupload: "gcr.io/k8s-prow/initupload:v20240802-66b115076"
-          entrypoint: "gcr.io/k8s-prow/entrypoint:v20240802-66b115076"
-          sidecar: "gcr.io/k8s-prow/sidecar:v20240802-66b115076"
+          clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076"
+          initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076"
+          entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076"
+          sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076"
         gcs_configuration:
           bucket: "knative-prow"
           path_strategy: "explicit"
@@ -44,10 +44,10 @@ plank:
         grace_period: 15s
         utility_images:
           # Update these versions when updating plank version in cluster.yaml
-          clonerefs: "gcr.io/k8s-prow/clonerefs:v20240802-66b115076"
-          initupload: "gcr.io/k8s-prow/initupload:v20240802-66b115076"
-          entrypoint: "gcr.io/k8s-prow/entrypoint:v20240802-66b115076"
-          sidecar: "gcr.io/k8s-prow/sidecar:v20240802-66b115076"
+          clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076"
+          initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076"
+          entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076"
+          sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076"
         gcs_configuration:
           bucket: "knative-prow"
           path_strategy: "explicit"

--- a/prow/jobs/custom/autobump-flaky-test-reporter.yaml
+++ b/prow/jobs/custom/autobump-flaky-test-reporter.yaml
@@ -19,7 +19,7 @@ periodics:
       report_template: '"The autobump-flaky-test-reporter periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:

--- a/prow/jobs/custom/autobump-prow-tests.yaml
+++ b/prow/jobs/custom/autobump-prow-tests.yaml
@@ -19,7 +19,7 @@ periodics:
       report_template: '"The autobump-prow-tests periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:

--- a/prow/jobs/custom/autobump-prow.yaml
+++ b/prow/jobs/custom/autobump-prow.yaml
@@ -19,7 +19,7 @@ periodics:
       report_template: '"The autobump-prow periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:

--- a/prow/jobs/custom/autodeploy-prow.yaml
+++ b/prow/jobs/custom/autodeploy-prow.yaml
@@ -38,7 +38,7 @@ periodics:
       report_template: '"The config-bootstrapper periodic has failed, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/config-bootstrapper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/config-bootstrapper:v20240802-66b115076
       imagePullPolicy: Always
       command:
       - config-bootstrapper

--- a/prow/jobs/custom/branchprotector.yaml
+++ b/prow/jobs/custom/branchprotector.yaml
@@ -41,7 +41,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20240802-66b115076
+      image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20240802-66b115076
       command:
       - branchprotector
       args:

--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Add a fake hook image here so that autobump.sh can bump only job configs
-# image: gcr.io/k8s-prow/hook:v20240802-66b115076
+# image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240802-66b115076
 # See
 # https://github.com/kubernetes/test-infra/blob/5815354584709c3f436e3d682110c673d224d7b1/prow/cmd/autobump/autobump.sh#L164
 
@@ -25,7 +25,7 @@ presubmits:
     cluster: prow-build
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240802-66b115076
         command:
         - checkconfig
         args:
@@ -48,7 +48,7 @@ presubmits:
     cluster: "prow-build"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240405-c76de01869
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/configurator:v20240405-c76de01869
         command:
         - configurator
         args:
@@ -373,7 +373,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240405-c76de01869
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/configurator:v20240405-c76de01869
         command:
         - configurator
         args:

--- a/prow/jobs/custom/label-sync.yaml
+++ b/prow/jobs/custom/label-sync.yaml
@@ -28,7 +28,7 @@ presubmits:
     spec:
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20240405-c76de01869
+        image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240405-c76de01869
         command:
         - label_sync
         args:
@@ -68,7 +68,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20240405-c76de01869
+      image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240405-c76de01869
       command:
       - label_sync
       args:
@@ -118,7 +118,7 @@ postsubmits:
     spec:
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20240405-c76de01869
+        image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240405-c76de01869
         command:
         - label_sync
         args:

--- a/prow/jobs/custom/peribolos.yaml
+++ b/prow/jobs/custom/peribolos.yaml
@@ -28,7 +28,7 @@ presubmits:
     - "main"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/peribolos:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20240802-66b115076
         command:
         - "peribolos"
         args:
@@ -67,7 +67,7 @@ presubmits:
     - "main"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/peribolos:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20240802-66b115076
         command:
         - "peribolos"
         args:
@@ -118,7 +118,7 @@ postsubmits:
       testgrid-tab-name: post-knative-peribolos
     spec:
       containers:
-      - image: gcr.io/k8s-prow/peribolos:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20240802-66b115076
         command:
         - "peribolos"
         args:
@@ -172,7 +172,7 @@ postsubmits:
       testgrid-tab-name: post-knative-extensions-peribolos
     spec:
       containers:
-      - image: gcr.io/k8s-prow/peribolos:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20240802-66b115076
         command:
         - "peribolos"
         args:
@@ -223,7 +223,7 @@ periodics:
     testgrid-tab-name: ci-knative-peribolos
   spec:
     containers:
-    - image: gcr.io/k8s-prow/peribolos:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20240802-66b115076
       command:
       - "peribolos"
       args:
@@ -271,7 +271,7 @@ periodics:
     testgrid-tab-name: ci-knative-extensions-peribolos
   spec:
     containers:
-    - image: gcr.io/k8s-prow/peribolos:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/peribolos:v20240802-66b115076
       command:
       - "peribolos"
       args:

--- a/prow/jobs/run_job.sh
+++ b/prow/jobs/run_job.sh
@@ -39,7 +39,7 @@ if [[ -n "${GITHUB_TOKEN_PATH}" ]]; then
     -v "${PWD}:${PWD}" -v "${CONFIG_YAML}:${CONFIG_YAML}" -v "${JOB_CONFIG_YAML}:${JOB_CONFIG_YAML}" \
     -v "${GITHUB_TOKEN_PATH}:${GITHUB_TOKEN_PATH}" \
     -w "${PWD}" \
-    gcr.io/k8s-prow/mkpj:v20240802-66b115076 \
+    us-docker.pkg.dev/k8s-infra-prow/images/mkpj:v20240802-66b115076 \
     "--job=${JOB_NAME}" "--config-path=${CONFIG_YAML}" "--job-config-path=${JOB_CONFIG_YAML}" \
     "--github-token-path=${GITHUB_TOKEN_PATH}" \
     >"${JOB_YAML}"
@@ -48,7 +48,7 @@ else
   docker run -i --rm \
     -v "${PWD}:${PWD}" -v "${CONFIG_YAML}:${CONFIG_YAML}" -v "${JOB_CONFIG_YAML}:${JOB_CONFIG_YAML}" \
     -w "${PWD}" \
-    gcr.io/k8s-prow/mkpj:v20240802-66b115076 \
+    us-docker.pkg.dev/k8s-infra-prow/images/mkpj:v20240802-66b115076 \
     "--job=${JOB_NAME}" "--config-path=${CONFIG_YAML}" "--job-config-path=${JOB_CONFIG_YAML}" \
     >"${JOB_YAML}" || failed=1
 


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/33210

Prow has been out of date because Kubernetes changed the prow image location.

The bumper should run successfully on the next run
bumper job: https://prow.knative.dev/job-history/gs/knative-prow/logs/ci-knative-prow-auto-bumper-for-auto-deploy