### PR TITLE
Use testgrid's configurator image from gcr.io registry

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -83,7 +83,7 @@ update-testgrid-config: confirm-main
 		-v "$(GOOGLE_APPLICATION_CREDENTIALS):$(GOOGLE_APPLICATION_CREDENTIALS)" \
 		-e "GOOGLE_APPLICATION_CREDENTIALS" \
 		-w "$(PWD)" \
-		gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da \
+		gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da9 \
 		"--oneshot" \
 		"--output=gs://$(TESTGRID_GCS)/config" \
 		"--yaml=$(realpath $(TESTGRID_CONFIG))"

--- a/config/Makefile
+++ b/config/Makefile
@@ -83,7 +83,7 @@ update-testgrid-config: confirm-main
 		-v "$(GOOGLE_APPLICATION_CREDENTIALS):$(GOOGLE_APPLICATION_CREDENTIALS)" \
 		-e "GOOGLE_APPLICATION_CREDENTIALS" \
 		-w "$(PWD)" \
-		gcr.io/k8s-prow/configurator:v20240731-a5d9345e59 \
+		gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da \
 		"--oneshot" \
 		"--output=gs://$(TESTGRID_GCS)/config" \
 		"--yaml=$(realpath $(TESTGRID_CONFIG))"

--- a/config/Makefile
+++ b/config/Makefile
@@ -83,7 +83,7 @@ update-testgrid-config: confirm-main
 		-v "$(GOOGLE_APPLICATION_CREDENTIALS):$(GOOGLE_APPLICATION_CREDENTIALS)" \
 		-e "GOOGLE_APPLICATION_CREDENTIALS" \
 		-w "$(PWD)" \
-		gcr.io/k8s-prow/configurator:v20220124-9887456efc \
+		gcr.io/k8s-prow/configurator:v20240731-a5d9345e59 \
 		"--oneshot" \
 		"--output=gs://$(TESTGRID_GCS)/config" \
 		"--yaml=$(realpath $(TESTGRID_CONFIG))"

--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -48,7 +48,7 @@ presubmits:
     cluster: "prow-build"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da9
         command:
         - configurator
         args:
@@ -373,7 +373,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da9
         command:
         - configurator
         args:

--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -48,7 +48,7 @@ presubmits:
     cluster: "prow-build"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da
         command:
         - configurator
         args:
@@ -373,7 +373,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da
         command:
         - configurator
         args:

--- a/prow/jobs/custom/infra.yaml
+++ b/prow/jobs/custom/infra.yaml
@@ -48,7 +48,7 @@ presubmits:
     cluster: "prow-build"
     spec:
       containers:
-      - image: us-docker.pkg.dev/k8s-infra-prow/images/configurator:v20240405-c76de01869
+      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
         command:
         - configurator
         args:
@@ -373,7 +373,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: us-docker.pkg.dev/k8s-infra-prow/images/configurator:v20240405-c76de01869
+      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
         command:
         - configurator
         args:


### PR DESCRIPTION
- Use testgrid's configurator image from gcr.io registry

Address issue described in: https://github.com/knative/infra/pull/520#issuecomment-2379238805


/cc @upodroid in case this's actual source of latest image for testgrid's configurator. 