### PR TITLE
Adjust peribolos gh api rps

### DIFF
--- a/prow/jobs/custom/peribolos.yaml
+++ b/prow/jobs/custom/peribolos.yaml
@@ -44,7 +44,8 @@ presubmits:
         - "--fix-org=true"
         - "--fix-org-members=true"
         - "--fix-repos=true"
-        - "--github-hourly-tokens=1200"
+        - "--github-hourly-tokens=600"
+        - "--github-allowed-burst=200"
         # Set --confirm=false to only validate the configuration file.
         - "--confirm=false"
         volumeMounts:
@@ -83,7 +84,8 @@ presubmits:
         - "--fix-org=true"
         - "--fix-org-members=true"
         - "--fix-repos=true"
-        - "--github-hourly-tokens=1200"
+        - "--github-hourly-tokens=600"
+        - "--github-allowed-burst=200"
         # Set --confirm=false to only validate the configuration file.
         - "--confirm=false"
         volumeMounts:


### PR DESCRIPTION
<!--
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
-->
**Which issue(s) this PR fixes**:<br>
Fixes #662 

- Adjust peribolos gh api rps

Still double the values of peribolos defaults. Let me know if you think we should go with default, or there's different issue e.g. with tokens.

https://github.com/kubernetes-sigs/prow/blob/main/cmd/peribolos/main.go#L41-L42

/cc @upodroid @cardil @dprotaso 