### PR TITLE
:bug: Bump timeout for CI peribolos to 4h

### DIFF
--- a/prow/jobs/custom/peribolos.yaml
+++ b/prow/jobs/custom/peribolos.yaml
@@ -205,6 +205,8 @@ periodics:
 - cron: "0 17 * * *"
   name: ci-knative-peribolos
   agent: kubernetes
+  decoration_config:
+    timeout: 4h0m0s
   decorate: true
   cluster: "prow-trusted"
   extra_refs:
@@ -251,6 +253,8 @@ periodics:
 - cron: "0 17 * * *"
   name: ci-knative-extensions-peribolos
   agent: kubernetes
+  decoration_config:
+    timeout: 4h0m0s
   decorate: true
   cluster: "prow-trusted"
   extra_refs:


### PR DESCRIPTION
## Changes
 - :bug: Bump timeout for CI peribolos to 4h

## Context

Should fix issues like https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-extensions-peribolos/1929946357959757824

**Which issue(s) this PR fixes**:<br>
Related to https://github.com/knative/infra/issues/662
Follow up on https://github.com/knative/infra/pull/665