### PR TITLE
Revert "bump peribolos log level to debug (#698)"

### DIFF
--- a/prow/jobs/custom/peribolos.yaml
+++ b/prow/jobs/custom/peribolos.yaml
@@ -135,7 +135,6 @@ postsubmits:
         - "--fix-repos=true"
         - "--require-self=false"
         - "--maximum-removal-delta=0.55"
-        - "--log-level=debug"
         - "--confirm=true"
         volumeMounts:
         - name: github-token
@@ -189,7 +188,6 @@ postsubmits:
         - "--fix-repos=true"
         - "--require-self=false"
         - "--maximum-removal-delta=0.55"
-        - "--log-level=debug"
         - "--confirm=true"
         volumeMounts:
         - name: github-token


### PR DESCRIPTION
Seems like one user who hadn't accepted the github invite was causing peribolos to fail. I've removed that user in the community repo.

This reverts commit f18e3ea45dd8537feb9b7972d59509a339621b64.

Revert log level back to info.

/assign @upodroid @cardil 