### PR TITLE
Increase timeout for EKB channel-integration tests

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -626,6 +626,8 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    decoration_config:
+      timeout: 3h0m0s
     name: channel-integration-tests-ssl_eventing-kafka-broker_main
     path_alias: knative.dev/eventing-kafka-broker
     rerun_command: /test channel-integration-tests-ssl
@@ -687,6 +689,8 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    decoration_config:
+      timeout: 3h0m0s
     name: channel-integration-tests-sasl-ssl_eventing-kafka-broker_main
     path_alias: knative.dev/eventing-kafka-broker
     rerun_command: /test channel-integration-tests-sasl-ssl
@@ -748,6 +752,8 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    decoration_config:
+      timeout: 3h0m0s
     name: channel-integration-tests-sasl-plain_eventing-kafka-broker_main
     path_alias: knative.dev/eventing-kafka-broker
     rerun_command: /test channel-integration-tests-sasl-plain

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
@@ -66,6 +66,7 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-tests.sh"]
     requirements: [docker]
+    timeout: 3h
     env:
       - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
         value: SSL
@@ -76,6 +77,7 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-tests.sh"]
     requirements: [docker]
+    timeout: 3h
     env:
       - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
         value: SASL_SSL
@@ -86,6 +88,7 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-tests.sh"]
     requirements: [docker]
+    timeout: 3h
     env:
       - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
         value: SASL_PLAIN


### PR DESCRIPTION
In EKB the channel-integration tests take a bit longer recently and so hit the default 2h timeout more often. So increasing it for now.