### PR TITLE
Add integration-tests-multicluster for knative/operator

### DIFF
--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -249,6 +249,60 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    name: integration-tests-multicluster_operator_main
+    path_alias: knative.dev/operator
+    rerun_command: /test integration-tests-multicluster
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./test/presubmit-tests.sh
+        - --run-test
+        - ./test/e2e-tests-multicluster.sh
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20260407-03476d3cc
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 12Gi
+          requests:
+            cpu: "4"
+            memory: 12Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /lib/modules
+          name: modules
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        type: testing
+      volumes:
+      - emptyDir: {}
+        name: docker-graph
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+    trigger: ((?m)^/test( | .* )integration-tests-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integration-tests-multicluster_operator_main,?($|\s.*))
+  - always_run: true
+    branches:
+    - ^main$
+    cluster: prow-build
+    decorate: true
     name: upgrade-tests_operator_main
     path_alias: knative.dev/operator
     rerun_command: /test upgrade-tests

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -18,6 +18,14 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
+  - name: integration-tests-multicluster
+    types: [presubmit]
+    command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/e2e-tests-multicluster.sh]
+    requirements: [docker]
+    excluded_requirements: [gcp]
+    resources: multicluster
+    timeout: 90m
+
   - name: upgrade-tests
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/e2e-upgrade-tests.sh]
@@ -54,3 +62,12 @@ jobs:
     requirements: [release]
     excluded_requirements: [gcp]
     max_concurrency: 1
+
+resources_presets:
+  multicluster:
+    requests:
+      cpu: 4000m
+      memory: 12Gi
+    limits:
+      cpu: 4000m
+      memory: 12Gi


### PR DESCRIPTION
<!--
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
-->
**Which issue(s) this PR fixes**:<br>
Fixes https://github.com/knative/operator/issues/2264

<!--
  Uncomment and fill out below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
<Explanation goes here>
-->

Adds a kind-DinD presubmit for knative/operator's multi-cluster e2e. The existing Boskos GKE `integration-tests` job is left in place for the single-cluster signal.

Companion operator PR that ships `test/e2e-tests-multicluster.sh`: https://github.com/knative/operator/pull/2267. We intentionally merge this infra PR first so that operator PR gets a real Prow test record for the new script. During the gap between this merge and the operator PR merge, other open operator PRs will fail on the missing script; reviewers should clear them with `/override integration-tests-multicluster_operator_main` until the operator PR lands.

<!--
  If there is any golang code in this PR please uncomment the
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
