### PR TITLE
bump images from test-infra automatically

### DIFF
--- a/prow/autobump-config/knative.yaml
+++ b/prow/autobump-config/knative.yaml
@@ -27,3 +27,8 @@ prefixes:
     repo: "https://github.com/kubernetes-sigs/boskos"
     summarise: false
     consistentImages: true
+  - name: "k8s-staging-test-infra GCR images"
+    prefix: "gcr.io/k8s-staging-test-infra"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: true


### PR DESCRIPTION
Kubernetes recently enforced image-cleanup for gcr.io/k8s-staging-test-infra, so all consumers need to use the autobumper to keep up.

This should fix the broken testgrid presubmit for this repo


@dprotaso 