### PR TITLE
chore: Remove EKB unit tests in favor of GH action

### DIFF
--- a/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-extensions/eventing-kafka-broker-main.gen.yaml
@@ -312,29 +312,6 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
-    name: unit-tests_eventing-kafka-broker_main
-    path_alias: knative.dev/eventing-kafka-broker
-    rerun_command: /test unit-tests
-    spec:
-      containers:
-      - command:
-        - runner.sh
-        - ./test/presubmit-tests.sh
-        - --unit-tests
-        image: us-docker.pkg.dev/knative-tests/images/prow-tests:v20260714-b47521e89
-        name: ""
-        resources: {}
-        securityContext:
-          privileged: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        type: testing
-    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_eventing-kafka-broker_main,?($|\s.*))
-  - always_run: true
-    branches:
-    - ^main$
-    cluster: prow-build
-    decorate: true
     name: integration-tests_eventing-kafka-broker_main
     path_alias: knative.dev/eventing-kafka-broker
     rerun_command: /test integration-tests

--- a/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-extensions/eventing-kafka-broker.yaml
@@ -9,11 +9,6 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --build-tests]
     excluded_requirements: [gcp]
 
-  - name: unit-tests
-    types: [presubmit]
-    command: [runner.sh, ./test/presubmit-tests.sh, --unit-tests]
-    excluded_requirements: [gcp]
-
   - name: integration-tests
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]


### PR DESCRIPTION
#### Changes

- chore: Remove EKB unit tests in favor of GH action

Per changes to Kafka setup there's a change to test container version rather than embedded KafkaCluster from debezium-core (that is no longer supported in newer versions). It's executed viac unit tests due to inclusion in surefire `verify` step.

This setup would require `DinD` enabled for unit tests. However, there's GH action already being executed that runs all unit tests and covers. Removing the redundant test from here.

https://github.com/knative-extensions/eventing-kafka-broker/pull/4779

https://github.com/knative-extensions/eventing-kafka-broker/blob/main/.github/workflows/knative-java-test.yaml